### PR TITLE
Big-method boxing cliff: unboxed Ref+prim folds, zero-alloc fuse, all-primitive specialization

### DIFF
--- a/benchmarks/src/scala/farray/BooleanAllOpsBench.scala
+++ b/benchmarks/src/scala/farray/BooleanAllOpsBench.scala
@@ -1,0 +1,127 @@
+package farray
+
+import org.openjdk.jmh.annotations.Benchmark
+
+// ONE long, mixed-stage Boolean pipeline run apples-to-apples across all 6 collections + a fused FArray
+// variant. flatMap·filter·map·flatMap·filter·map · zip·map · zipWithIndex · filter·map·flatMap·filter · fold.
+// Every stage exists on every collection; every lambda is distinct; the chain is long enough that each
+// eager stage allocates a fresh intermediate (List/Vector box every Boolean; IArray/Chunk box once their
+// shared map/fold goes megamorphic) while FArray stays an unboxed BooleanArr the whole way, and `.fuse`
+// runs it in ONE pass with no intermediate collections.
+class BooleanAllOpsBench extends BooleanInputs {
+
+  @Benchmark def list(): Int = listInput
+    .flatMap(b => List(b, !b))
+    .filter(identity)
+    .map(!_)
+    .flatMap(b => List(b, b & true))
+    .filter(b => b | true)
+    .map(!_)
+    .zip(listInput.map(!_))
+    .map((a, b) => a ^ b)
+    .zipWithIndex
+    .filter((v, i) => i % 4 != 0)
+    .map((v, i) => v ^ (i % 2 == 0))
+    .flatMap(b => List(b, !b))
+    .filter(identity)
+    .foldLeft(0)((acc, x) => acc + (if (x) 1 else 0))
+
+  @Benchmark def vector(): Int = vectorInput
+    .flatMap(b => Vector(b, !b))
+    .filter(identity)
+    .map(!_)
+    .flatMap(b => Vector(b, b & true))
+    .filter(b => b | true)
+    .map(!_)
+    .zip(vectorInput.map(!_))
+    .map((a, b) => a ^ b)
+    .zipWithIndex
+    .filter((v, i) => i % 4 != 0)
+    .map((v, i) => v ^ (i % 2 == 0))
+    .flatMap(b => Vector(b, !b))
+    .filter(identity)
+    .foldLeft(0)((acc, x) => acc + (if (x) 1 else 0))
+
+  @Benchmark def iarray(): Int = iarrayInput
+    .flatMap(b => IArray(b, !b))
+    .filter(identity)
+    .map(!_)
+    .flatMap(b => IArray(b, b & true))
+    .filter(b => b | true)
+    .map(!_)
+    .zip(iarrayInput.map(!_))
+    .map((a, b) => a ^ b)
+    .zipWithIndex
+    .filter((v, i) => i % 4 != 0)
+    .map((v, i) => v ^ (i % 2 == 0))
+    .flatMap(b => IArray(b, !b))
+    .filter(identity)
+    .foldLeft(0)((acc, x) => acc + (if (x) 1 else 0))
+
+  @Benchmark def farray(): Int = farrayInput
+    .flatMap(b => FArray(b, !b))
+    .filter(identity)
+    .map(!_)
+    .flatMap(b => FArray(b, b & true))
+    .filter(b => b | true)
+    .map(!_)
+    .zip(farrayInput.map(!_))
+    .map((a, b) => a ^ b)
+    .zipWithIndex
+    .filter((v, i) => i % 4 != 0)
+    .map((v, i) => v ^ (i % 2 == 0))
+    .flatMap(b => FArray(b, !b))
+    .filter(identity)
+    .foldLeft(0)((acc, x) => acc + (if (x) 1 else 0))
+
+  @Benchmark def fs2chunk(): Int = fs2ChunkInput
+    .flatMap(b => fs2.Chunk(b, !b))
+    .filter(identity)
+    .map(!_)
+    .flatMap(b => fs2.Chunk(b, b & true))
+    .filter(b => b | true)
+    .map(!_)
+    .zip(fs2ChunkInput.map(!_))
+    .map((a, b) => a ^ b)
+    .zipWithIndex
+    .filter((v, i) => i % 4 != 0)
+    .map((v, i) => v ^ (i % 2 == 0))
+    .flatMap(b => fs2.Chunk(b, !b))
+    .filter(identity)
+    .foldLeft(0)((acc, x) => acc + (if (x) 1 else 0))
+
+  @Benchmark def ziochunk(): Int = zioChunkInput
+    .flatMap(b => zio.Chunk(b, !b))
+    .filter(identity)
+    .map(!_)
+    .flatMap(b => zio.Chunk(b, b & true))
+    .filter(b => b | true)
+    .map(!_)
+    .zip(zioChunkInput.map(!_))
+    .map((a, b) => a ^ b)
+    .zipWithIndex
+    .filter((v, i) => i % 4 != 0)
+    .map((v, i) => v ^ (i % 2 == 0))
+    .flatMap(b => zio.Chunk(b, !b))
+    .filter(identity)
+    .foldLeft(0)((acc, x) => acc + (if (x) 1 else 0))
+
+  @Benchmark def farrayFused(): Int = {
+    val zipSrc = farrayInput.map(!_)
+    farrayInput.fuse
+      .flatMap(b => FArray(b, !b))
+      .filter(identity)
+      .map(!_)
+      .flatMap(b => FArray(b, b & true))
+      .filter(b => b | true)
+      .map(!_)
+      .zip(zipSrc)
+      .map((a, b) => a ^ b)
+      .zipWithIndex
+      .filter((v, i) => i % 4 != 0)
+      .map((v, i) => v ^ (i % 2 == 0))
+      .flatMap(b => FArray(b, !b))
+      .filter(identity)
+      .foldLeft(0)((acc, x) => acc + (if (x) 1 else 0))
+  }
+}

--- a/benchmarks/src/scala/farray/BooleanInputs.scala
+++ b/benchmarks/src/scala/farray/BooleanInputs.scala
@@ -1,0 +1,27 @@
+package farray
+
+import org.openjdk.jmh.annotations.{Param, Setup}
+
+/** Primitive-Boolean inputs — exercises FArray's specialized BooleanArr path against the competitors. */
+abstract class BooleanInputs extends CommonParams {
+  @Param(Array("0", "1", "10", "100", "1000", "10000", "100000"))
+  var size: Int = 1000
+
+  var listInput: List[Boolean] = _
+  var vectorInput: Vector[Boolean] = _
+  var iarrayInput: IArray[Boolean] = _
+  var farrayInput: FArray[Boolean] = _
+  var fs2ChunkInput: fs2.Chunk[Boolean] = _
+  var zioChunkInput: zio.Chunk[Boolean] = _
+
+  @Setup
+  def setup(): Unit = {
+    val arr = Array.tabulate(size)(i => i % 2 == 0)
+    listInput = arr.toList
+    vectorInput = arr.toVector
+    iarrayInput = IArray.tabulate(size)(i => i % 2 == 0)
+    farrayInput = FArray.tabulate(size)(i => i % 2 == 0)
+    fs2ChunkInput = fs2.Chunk.array(arr)
+    zioChunkInput = zio.Chunk.fromArray(arr)
+  }
+}

--- a/benchmarks/src/scala/farray/ByteAllOpsBench.scala
+++ b/benchmarks/src/scala/farray/ByteAllOpsBench.scala
@@ -1,0 +1,127 @@
+package farray
+
+import org.openjdk.jmh.annotations.Benchmark
+
+// ONE long, mixed-stage Byte pipeline run apples-to-apples across all 6 collections + a fused FArray
+// variant. flatMap·filter·map·flatMap·filter·map · zip·map · zipWithIndex · filter·map·flatMap·filter · fold.
+// Every stage exists on every collection; every lambda is distinct; the chain is long enough that each
+// eager stage allocates a fresh intermediate (List/Vector box every Byte; IArray/Chunk box once their
+// shared map/fold goes megamorphic) while FArray stays an unboxed ByteArr the whole way, and `.fuse`
+// runs it in ONE pass with no intermediate collections.
+class ByteAllOpsBench extends ByteInputs {
+
+  @Benchmark def list(): Int = listInput
+    .flatMap(x => List(x, (x + 1).toByte))
+    .filter(_ % 3 != 0)
+    .map(b => (b * 2).toByte)
+    .flatMap(x => List(x, (x ^ 5).toByte))
+    .filter(_ % 2 == 0)
+    .map(b => (b - 7).toByte)
+    .zip(listInput.map(b => (b + 100).toByte))
+    .map((a, b) => (a + b).toByte)
+    .zipWithIndex
+    .filter((v, i) => (v + i) % 4 != 0)
+    .map((v, i) => (v - i).toByte)
+    .flatMap(x => List(x, (x + 3).toByte))
+    .filter(_ != 0)
+    .foldLeft(0)((acc, x) => acc + x)
+
+  @Benchmark def vector(): Int = vectorInput
+    .flatMap(x => Vector(x, (x + 1).toByte))
+    .filter(_ % 3 != 0)
+    .map(b => (b * 2).toByte)
+    .flatMap(x => Vector(x, (x ^ 5).toByte))
+    .filter(_ % 2 == 0)
+    .map(b => (b - 7).toByte)
+    .zip(vectorInput.map(b => (b + 100).toByte))
+    .map((a, b) => (a + b).toByte)
+    .zipWithIndex
+    .filter((v, i) => (v + i) % 4 != 0)
+    .map((v, i) => (v - i).toByte)
+    .flatMap(x => Vector(x, (x + 3).toByte))
+    .filter(_ != 0)
+    .foldLeft(0)((acc, x) => acc + x)
+
+  @Benchmark def iarray(): Int = iarrayInput
+    .flatMap(x => IArray(x, (x + 1).toByte))
+    .filter(_ % 3 != 0)
+    .map(b => (b * 2).toByte)
+    .flatMap(x => IArray(x, (x ^ 5).toByte))
+    .filter(_ % 2 == 0)
+    .map(b => (b - 7).toByte)
+    .zip(iarrayInput.map(b => (b + 100).toByte))
+    .map((a, b) => (a + b).toByte)
+    .zipWithIndex
+    .filter((v, i) => (v + i) % 4 != 0)
+    .map((v, i) => (v - i).toByte)
+    .flatMap(x => IArray(x, (x + 3).toByte))
+    .filter(_ != 0)
+    .foldLeft(0)((acc, x) => acc + x)
+
+  @Benchmark def farray(): Int = farrayInput
+    .flatMap(x => FArray(x, (x + 1).toByte))
+    .filter(_ % 3 != 0)
+    .map(b => (b * 2).toByte)
+    .flatMap(x => FArray(x, (x ^ 5).toByte))
+    .filter(_ % 2 == 0)
+    .map(b => (b - 7).toByte)
+    .zip(farrayInput.map(b => (b + 100).toByte))
+    .map((a, b) => (a + b).toByte)
+    .zipWithIndex
+    .filter((v, i) => (v + i) % 4 != 0)
+    .map((v, i) => (v - i).toByte)
+    .flatMap(x => FArray(x, (x + 3).toByte))
+    .filter(_ != 0)
+    .foldLeft(0)((acc, x) => acc + x)
+
+  @Benchmark def fs2chunk(): Int = fs2ChunkInput
+    .flatMap(x => fs2.Chunk(x, (x + 1).toByte))
+    .filter(_ % 3 != 0)
+    .map(b => (b * 2).toByte)
+    .flatMap(x => fs2.Chunk(x, (x ^ 5).toByte))
+    .filter(_ % 2 == 0)
+    .map(b => (b - 7).toByte)
+    .zip(fs2ChunkInput.map(b => (b + 100).toByte))
+    .map((a, b) => (a + b).toByte)
+    .zipWithIndex
+    .filter((v, i) => (v + i) % 4 != 0)
+    .map((v, i) => (v - i).toByte)
+    .flatMap(x => fs2.Chunk(x, (x + 3).toByte))
+    .filter(_ != 0)
+    .foldLeft(0)((acc, x) => acc + x)
+
+  @Benchmark def ziochunk(): Int = zioChunkInput
+    .flatMap(x => zio.Chunk(x, (x + 1).toByte))
+    .filter(_ % 3 != 0)
+    .map(b => (b * 2).toByte)
+    .flatMap(x => zio.Chunk(x, (x ^ 5).toByte))
+    .filter(_ % 2 == 0)
+    .map(b => (b - 7).toByte)
+    .zip(zioChunkInput.map(b => (b + 100).toByte))
+    .map((a, b) => (a + b).toByte)
+    .zipWithIndex
+    .filter((v, i) => (v + i) % 4 != 0)
+    .map((v, i) => (v - i).toByte)
+    .flatMap(x => zio.Chunk(x, (x + 3).toByte))
+    .filter(_ != 0)
+    .foldLeft(0)((acc, x) => acc + x)
+
+  @Benchmark def farrayFused(): Int = {
+    val zipSrc = farrayInput.map(b => (b + 100).toByte)
+    farrayInput.fuse
+      .flatMap(x => FArray(x, (x + 1).toByte))
+      .filter(_ % 3 != 0)
+      .map(b => (b * 2).toByte)
+      .flatMap(x => FArray(x, (x ^ 5).toByte))
+      .filter(_ % 2 == 0)
+      .map(b => (b - 7).toByte)
+      .zip(zipSrc)
+      .map((a, b) => (a + b).toByte)
+      .zipWithIndex
+      .filter((v, i) => (v + i) % 4 != 0)
+      .map((v, i) => (v - i).toByte)
+      .flatMap(x => FArray(x, (x + 3).toByte))
+      .filter(_ != 0)
+      .foldLeft(0)((acc, x) => acc + x)
+  }
+}

--- a/benchmarks/src/scala/farray/ByteInputs.scala
+++ b/benchmarks/src/scala/farray/ByteInputs.scala
@@ -1,0 +1,27 @@
+package farray
+
+import org.openjdk.jmh.annotations.{Param, Setup}
+
+/** Primitive-Byte inputs — exercises FArray's specialized ByteArr path against the competitors. */
+abstract class ByteInputs extends CommonParams {
+  @Param(Array("0", "1", "10", "100", "1000", "10000", "100000"))
+  var size: Int = 1000
+
+  var listInput: List[Byte] = _
+  var vectorInput: Vector[Byte] = _
+  var iarrayInput: IArray[Byte] = _
+  var farrayInput: FArray[Byte] = _
+  var fs2ChunkInput: fs2.Chunk[Byte] = _
+  var zioChunkInput: zio.Chunk[Byte] = _
+
+  @Setup
+  def setup(): Unit = {
+    val arr = Array.tabulate(size)(i => (i % 127).toByte)
+    listInput = arr.toList
+    vectorInput = arr.toVector
+    iarrayInput = IArray.tabulate(size)(i => (i % 127).toByte)
+    farrayInput = FArray.tabulate(size)(i => (i % 127).toByte)
+    fs2ChunkInput = fs2.Chunk.array(arr)
+    zioChunkInput = zio.Chunk.fromArray(arr)
+  }
+}

--- a/benchmarks/src/scala/farray/CharAllOpsBench.scala
+++ b/benchmarks/src/scala/farray/CharAllOpsBench.scala
@@ -1,0 +1,127 @@
+package farray
+
+import org.openjdk.jmh.annotations.Benchmark
+
+// ONE long, mixed-stage Char pipeline run apples-to-apples across all 6 collections + a fused FArray
+// variant. flatMap·filter·map·flatMap·filter·map · zip·map · zipWithIndex · filter·map·flatMap·filter · fold.
+// Every stage exists on every collection; every lambda is distinct; the chain is long enough that each
+// eager stage allocates a fresh intermediate (List/Vector box every Char; IArray/Chunk box once their
+// shared map/fold goes megamorphic) while FArray stays an unboxed CharArr the whole way, and `.fuse`
+// runs it in ONE pass with no intermediate collections.
+class CharAllOpsBench extends CharInputs {
+
+  @Benchmark def list(): Int = listInput
+    .flatMap(c => List(c, c.toUpper))
+    .filter(_ != 'b')
+    .map(c => (c + 1).toChar)
+    .flatMap(c => List(c, c.toLower))
+    .filter(_ != 'z')
+    .map(c => (c ^ 2).toChar)
+    .zip(listInput.map(c => (c + 1).toChar))
+    .map((a, b) => (a + b).toChar)
+    .zipWithIndex
+    .filter((v, i) => i % 4 != 0)
+    .map((v, i) => (v + i).toChar)
+    .flatMap(c => List(c, c.toUpper))
+    .filter(_ != 'q')
+    .foldLeft(0)((acc, x) => acc + x.toInt)
+
+  @Benchmark def vector(): Int = vectorInput
+    .flatMap(c => Vector(c, c.toUpper))
+    .filter(_ != 'b')
+    .map(c => (c + 1).toChar)
+    .flatMap(c => Vector(c, c.toLower))
+    .filter(_ != 'z')
+    .map(c => (c ^ 2).toChar)
+    .zip(vectorInput.map(c => (c + 1).toChar))
+    .map((a, b) => (a + b).toChar)
+    .zipWithIndex
+    .filter((v, i) => i % 4 != 0)
+    .map((v, i) => (v + i).toChar)
+    .flatMap(c => Vector(c, c.toUpper))
+    .filter(_ != 'q')
+    .foldLeft(0)((acc, x) => acc + x.toInt)
+
+  @Benchmark def iarray(): Int = iarrayInput
+    .flatMap(c => IArray(c, c.toUpper))
+    .filter(_ != 'b')
+    .map(c => (c + 1).toChar)
+    .flatMap(c => IArray(c, c.toLower))
+    .filter(_ != 'z')
+    .map(c => (c ^ 2).toChar)
+    .zip(iarrayInput.map(c => (c + 1).toChar))
+    .map((a, b) => (a + b).toChar)
+    .zipWithIndex
+    .filter((v, i) => i % 4 != 0)
+    .map((v, i) => (v + i).toChar)
+    .flatMap(c => IArray(c, c.toUpper))
+    .filter(_ != 'q')
+    .foldLeft(0)((acc, x) => acc + x.toInt)
+
+  @Benchmark def farray(): Int = farrayInput
+    .flatMap(c => FArray(c, c.toUpper))
+    .filter(_ != 'b')
+    .map(c => (c + 1).toChar)
+    .flatMap(c => FArray(c, c.toLower))
+    .filter(_ != 'z')
+    .map(c => (c ^ 2).toChar)
+    .zip(farrayInput.map(c => (c + 1).toChar))
+    .map((a, b) => (a + b).toChar)
+    .zipWithIndex
+    .filter((v, i) => i % 4 != 0)
+    .map((v, i) => (v + i).toChar)
+    .flatMap(c => FArray(c, c.toUpper))
+    .filter(_ != 'q')
+    .foldLeft(0)((acc, x) => acc + x.toInt)
+
+  @Benchmark def fs2chunk(): Int = fs2ChunkInput
+    .flatMap(c => fs2.Chunk(c, c.toUpper))
+    .filter(_ != 'b')
+    .map(c => (c + 1).toChar)
+    .flatMap(c => fs2.Chunk(c, c.toLower))
+    .filter(_ != 'z')
+    .map(c => (c ^ 2).toChar)
+    .zip(fs2ChunkInput.map(c => (c + 1).toChar))
+    .map((a, b) => (a + b).toChar)
+    .zipWithIndex
+    .filter((v, i) => i % 4 != 0)
+    .map((v, i) => (v + i).toChar)
+    .flatMap(c => fs2.Chunk(c, c.toUpper))
+    .filter(_ != 'q')
+    .foldLeft(0)((acc, x) => acc + x.toInt)
+
+  @Benchmark def ziochunk(): Int = zioChunkInput
+    .flatMap(c => zio.Chunk(c, c.toUpper))
+    .filter(_ != 'b')
+    .map(c => (c + 1).toChar)
+    .flatMap(c => zio.Chunk(c, c.toLower))
+    .filter(_ != 'z')
+    .map(c => (c ^ 2).toChar)
+    .zip(zioChunkInput.map(c => (c + 1).toChar))
+    .map((a, b) => (a + b).toChar)
+    .zipWithIndex
+    .filter((v, i) => i % 4 != 0)
+    .map((v, i) => (v + i).toChar)
+    .flatMap(c => zio.Chunk(c, c.toUpper))
+    .filter(_ != 'q')
+    .foldLeft(0)((acc, x) => acc + x.toInt)
+
+  @Benchmark def farrayFused(): Int = {
+    val zipSrc = farrayInput.map(c => (c + 1).toChar)
+    farrayInput.fuse
+      .flatMap(c => FArray(c, c.toUpper))
+      .filter(_ != 'b')
+      .map(c => (c + 1).toChar)
+      .flatMap(c => FArray(c, c.toLower))
+      .filter(_ != 'z')
+      .map(c => (c ^ 2).toChar)
+      .zip(zipSrc)
+      .map((a, b) => (a + b).toChar)
+      .zipWithIndex
+      .filter((v, i) => i % 4 != 0)
+      .map((v, i) => (v + i).toChar)
+      .flatMap(c => FArray(c, c.toUpper))
+      .filter(_ != 'q')
+      .foldLeft(0)((acc, x) => acc + x.toInt)
+  }
+}

--- a/benchmarks/src/scala/farray/CharInputs.scala
+++ b/benchmarks/src/scala/farray/CharInputs.scala
@@ -1,0 +1,27 @@
+package farray
+
+import org.openjdk.jmh.annotations.{Param, Setup}
+
+/** Primitive-Char inputs — exercises FArray's specialized CharArr path against the competitors. */
+abstract class CharInputs extends CommonParams {
+  @Param(Array("0", "1", "10", "100", "1000", "10000", "100000"))
+  var size: Int = 1000
+
+  var listInput: List[Char] = _
+  var vectorInput: Vector[Char] = _
+  var iarrayInput: IArray[Char] = _
+  var farrayInput: FArray[Char] = _
+  var fs2ChunkInput: fs2.Chunk[Char] = _
+  var zioChunkInput: zio.Chunk[Char] = _
+
+  @Setup
+  def setup(): Unit = {
+    val arr = Array.tabulate(size)(i => ('a' + (i % 26)).toChar)
+    listInput = arr.toList
+    vectorInput = arr.toVector
+    iarrayInput = IArray.tabulate(size)(i => ('a' + (i % 26)).toChar)
+    farrayInput = FArray.tabulate(size)(i => ('a' + (i % 26)).toChar)
+    fs2ChunkInput = fs2.Chunk.array(arr)
+    zioChunkInput = zio.Chunk.fromArray(arr)
+  }
+}

--- a/benchmarks/src/scala/farray/DoubleAllOpsBench.scala
+++ b/benchmarks/src/scala/farray/DoubleAllOpsBench.scala
@@ -1,0 +1,127 @@
+package farray
+
+import org.openjdk.jmh.annotations.Benchmark
+
+// ONE long, mixed-stage Double pipeline run apples-to-apples across all 6 collections + a fused FArray
+// variant. flatMap·filter·map·flatMap·filter·map · zip·map · zipWithIndex · filter·map·flatMap·filter · fold.
+// Every stage exists on every collection; every lambda is distinct; the chain is long enough that each
+// eager stage allocates a fresh intermediate (List/Vector box every Double; IArray/Chunk box once their
+// shared map/fold goes megamorphic) while FArray stays an unboxed DoubleArr the whole way, and `.fuse`
+// runs it in ONE pass with no intermediate collections.
+class DoubleAllOpsBench extends DoubleInputs {
+
+  @Benchmark def list(): Double = listInput
+    .flatMap(x => List(x, x + 1.0))
+    .filter(_ > 1.5)
+    .map(_ * 2.0)
+    .flatMap(x => List(x, x - 0.5))
+    .filter(_ < 5.0e6)
+    .map(_ + 0.25)
+    .zip(listInput.map(_ + 100.0))
+    .map((a, b) => a + b)
+    .zipWithIndex
+    .filter((v, i) => i % 4 != 0)
+    .map((v, i) => v - i)
+    .flatMap(x => List(x, x + 3.0))
+    .filter(_ > 0.0)
+    .foldLeft(0.0)((acc, x) => acc + x)
+
+  @Benchmark def vector(): Double = vectorInput
+    .flatMap(x => Vector(x, x + 1.0))
+    .filter(_ > 1.5)
+    .map(_ * 2.0)
+    .flatMap(x => Vector(x, x - 0.5))
+    .filter(_ < 5.0e6)
+    .map(_ + 0.25)
+    .zip(vectorInput.map(_ + 100.0))
+    .map((a, b) => a + b)
+    .zipWithIndex
+    .filter((v, i) => i % 4 != 0)
+    .map((v, i) => v - i)
+    .flatMap(x => Vector(x, x + 3.0))
+    .filter(_ > 0.0)
+    .foldLeft(0.0)((acc, x) => acc + x)
+
+  @Benchmark def iarray(): Double = iarrayInput
+    .flatMap(x => IArray(x, x + 1.0))
+    .filter(_ > 1.5)
+    .map(_ * 2.0)
+    .flatMap(x => IArray(x, x - 0.5))
+    .filter(_ < 5.0e6)
+    .map(_ + 0.25)
+    .zip(iarrayInput.map(_ + 100.0))
+    .map((a, b) => a + b)
+    .zipWithIndex
+    .filter((v, i) => i % 4 != 0)
+    .map((v, i) => v - i)
+    .flatMap(x => IArray(x, x + 3.0))
+    .filter(_ > 0.0)
+    .foldLeft(0.0)((acc, x) => acc + x)
+
+  @Benchmark def farray(): Double = farrayInput
+    .flatMap(x => FArray(x, x + 1.0))
+    .filter(_ > 1.5)
+    .map(_ * 2.0)
+    .flatMap(x => FArray(x, x - 0.5))
+    .filter(_ < 5.0e6)
+    .map(_ + 0.25)
+    .zip(farrayInput.map(_ + 100.0))
+    .map((a, b) => a + b)
+    .zipWithIndex
+    .filter((v, i) => i % 4 != 0)
+    .map((v, i) => v - i)
+    .flatMap(x => FArray(x, x + 3.0))
+    .filter(_ > 0.0)
+    .foldLeft(0.0)((acc, x) => acc + x)
+
+  @Benchmark def fs2chunk(): Double = fs2ChunkInput
+    .flatMap(x => fs2.Chunk(x, x + 1.0))
+    .filter(_ > 1.5)
+    .map(_ * 2.0)
+    .flatMap(x => fs2.Chunk(x, x - 0.5))
+    .filter(_ < 5.0e6)
+    .map(_ + 0.25)
+    .zip(fs2ChunkInput.map(_ + 100.0))
+    .map((a, b) => a + b)
+    .zipWithIndex
+    .filter((v, i) => i % 4 != 0)
+    .map((v, i) => v - i)
+    .flatMap(x => fs2.Chunk(x, x + 3.0))
+    .filter(_ > 0.0)
+    .foldLeft(0.0)((acc, x) => acc + x)
+
+  @Benchmark def ziochunk(): Double = zioChunkInput
+    .flatMap(x => zio.Chunk(x, x + 1.0))
+    .filter(_ > 1.5)
+    .map(_ * 2.0)
+    .flatMap(x => zio.Chunk(x, x - 0.5))
+    .filter(_ < 5.0e6)
+    .map(_ + 0.25)
+    .zip(zioChunkInput.map(_ + 100.0))
+    .map((a, b) => a + b)
+    .zipWithIndex
+    .filter((v, i) => i % 4 != 0)
+    .map((v, i) => v - i)
+    .flatMap(x => zio.Chunk(x, x + 3.0))
+    .filter(_ > 0.0)
+    .foldLeft(0.0)((acc, x) => acc + x)
+
+  @Benchmark def farrayFused(): Double = {
+    val zipSrc = farrayInput.map(_ + 100.0)
+    farrayInput.fuse
+      .flatMap(x => FArray(x, x + 1.0))
+      .filter(_ > 1.5)
+      .map(_ * 2.0)
+      .flatMap(x => FArray(x, x - 0.5))
+      .filter(_ < 5.0e6)
+      .map(_ + 0.25)
+      .zip(zipSrc)
+      .map((a, b) => a + b)
+      .zipWithIndex
+      .filter((v, i) => i % 4 != 0)
+      .map((v, i) => v - i)
+      .flatMap(x => FArray(x, x + 3.0))
+      .filter(_ > 0.0)
+      .foldLeft(0.0)((acc, x) => acc + x)
+  }
+}

--- a/benchmarks/src/scala/farray/DoubleInputs.scala
+++ b/benchmarks/src/scala/farray/DoubleInputs.scala
@@ -1,0 +1,27 @@
+package farray
+
+import org.openjdk.jmh.annotations.{Param, Setup}
+
+/** Primitive-Double inputs — exercises FArray's specialized DoubleArr path against the competitors. */
+abstract class DoubleInputs extends CommonParams {
+  @Param(Array("0", "1", "10", "100", "1000", "10000", "100000"))
+  var size: Int = 1000
+
+  var listInput: List[Double] = _
+  var vectorInput: Vector[Double] = _
+  var iarrayInput: IArray[Double] = _
+  var farrayInput: FArray[Double] = _
+  var fs2ChunkInput: fs2.Chunk[Double] = _
+  var zioChunkInput: zio.Chunk[Double] = _
+
+  @Setup
+  def setup(): Unit = {
+    val arr = Array.tabulate(size)(i => i.toDouble)
+    listInput = arr.toList
+    vectorInput = arr.toVector
+    iarrayInput = IArray.tabulate(size)(i => i.toDouble)
+    farrayInput = FArray.tabulate(size)(i => i.toDouble)
+    fs2ChunkInput = fs2.Chunk.array(arr)
+    zioChunkInput = zio.Chunk.fromArray(arr)
+  }
+}

--- a/benchmarks/src/scala/farray/FloatAllOpsBench.scala
+++ b/benchmarks/src/scala/farray/FloatAllOpsBench.scala
@@ -1,0 +1,127 @@
+package farray
+
+import org.openjdk.jmh.annotations.Benchmark
+
+// ONE long, mixed-stage Float pipeline run apples-to-apples across all 6 collections + a fused FArray
+// variant. flatMap·filter·map·flatMap·filter·map · zip·map · zipWithIndex · filter·map·flatMap·filter · fold.
+// Every stage exists on every collection; every lambda is distinct; the chain is long enough that each
+// eager stage allocates a fresh intermediate (List/Vector box every Float; IArray/Chunk box once their
+// shared map/fold goes megamorphic) while FArray stays an unboxed FloatArr the whole way, and `.fuse`
+// runs it in ONE pass with no intermediate collections.
+class FloatAllOpsBench extends FloatInputs {
+
+  @Benchmark def list(): Float = listInput
+    .flatMap(x => List(x, x + 1.0f))
+    .filter(_ > 1.5f)
+    .map(_ * 2.0f)
+    .flatMap(x => List(x, x - 0.5f))
+    .filter(_ < 5.0e6f)
+    .map(_ + 0.25f)
+    .zip(listInput.map(_ + 100.0f))
+    .map((a, b) => a + b)
+    .zipWithIndex
+    .filter((v, i) => i % 4 != 0)
+    .map((v, i) => v - i)
+    .flatMap(x => List(x, x + 3.0f))
+    .filter(_ > 0.0f)
+    .foldLeft(0.0f)((acc, x) => acc + x)
+
+  @Benchmark def vector(): Float = vectorInput
+    .flatMap(x => Vector(x, x + 1.0f))
+    .filter(_ > 1.5f)
+    .map(_ * 2.0f)
+    .flatMap(x => Vector(x, x - 0.5f))
+    .filter(_ < 5.0e6f)
+    .map(_ + 0.25f)
+    .zip(vectorInput.map(_ + 100.0f))
+    .map((a, b) => a + b)
+    .zipWithIndex
+    .filter((v, i) => i % 4 != 0)
+    .map((v, i) => v - i)
+    .flatMap(x => Vector(x, x + 3.0f))
+    .filter(_ > 0.0f)
+    .foldLeft(0.0f)((acc, x) => acc + x)
+
+  @Benchmark def iarray(): Float = iarrayInput
+    .flatMap(x => IArray(x, x + 1.0f))
+    .filter(_ > 1.5f)
+    .map(_ * 2.0f)
+    .flatMap(x => IArray(x, x - 0.5f))
+    .filter(_ < 5.0e6f)
+    .map(_ + 0.25f)
+    .zip(iarrayInput.map(_ + 100.0f))
+    .map((a, b) => a + b)
+    .zipWithIndex
+    .filter((v, i) => i % 4 != 0)
+    .map((v, i) => v - i)
+    .flatMap(x => IArray(x, x + 3.0f))
+    .filter(_ > 0.0f)
+    .foldLeft(0.0f)((acc, x) => acc + x)
+
+  @Benchmark def farray(): Float = farrayInput
+    .flatMap(x => FArray(x, x + 1.0f))
+    .filter(_ > 1.5f)
+    .map(_ * 2.0f)
+    .flatMap(x => FArray(x, x - 0.5f))
+    .filter(_ < 5.0e6f)
+    .map(_ + 0.25f)
+    .zip(farrayInput.map(_ + 100.0f))
+    .map((a, b) => a + b)
+    .zipWithIndex
+    .filter((v, i) => i % 4 != 0)
+    .map((v, i) => v - i)
+    .flatMap(x => FArray(x, x + 3.0f))
+    .filter(_ > 0.0f)
+    .foldLeft(0.0f)((acc, x) => acc + x)
+
+  @Benchmark def fs2chunk(): Float = fs2ChunkInput
+    .flatMap(x => fs2.Chunk(x, x + 1.0f))
+    .filter(_ > 1.5f)
+    .map(_ * 2.0f)
+    .flatMap(x => fs2.Chunk(x, x - 0.5f))
+    .filter(_ < 5.0e6f)
+    .map(_ + 0.25f)
+    .zip(fs2ChunkInput.map(_ + 100.0f))
+    .map((a, b) => a + b)
+    .zipWithIndex
+    .filter((v, i) => i % 4 != 0)
+    .map((v, i) => v - i)
+    .flatMap(x => fs2.Chunk(x, x + 3.0f))
+    .filter(_ > 0.0f)
+    .foldLeft(0.0f)((acc, x) => acc + x)
+
+  @Benchmark def ziochunk(): Float = zioChunkInput
+    .flatMap(x => zio.Chunk(x, x + 1.0f))
+    .filter(_ > 1.5f)
+    .map(_ * 2.0f)
+    .flatMap(x => zio.Chunk(x, x - 0.5f))
+    .filter(_ < 5.0e6f)
+    .map(_ + 0.25f)
+    .zip(zioChunkInput.map(_ + 100.0f))
+    .map((a, b) => a + b)
+    .zipWithIndex
+    .filter((v, i) => i % 4 != 0)
+    .map((v, i) => v - i)
+    .flatMap(x => zio.Chunk(x, x + 3.0f))
+    .filter(_ > 0.0f)
+    .foldLeft(0.0f)((acc, x) => acc + x)
+
+  @Benchmark def farrayFused(): Float = {
+    val zipSrc = farrayInput.map(_ + 100.0f)
+    farrayInput.fuse
+      .flatMap(x => FArray(x, x + 1.0f))
+      .filter(_ > 1.5f)
+      .map(_ * 2.0f)
+      .flatMap(x => FArray(x, x - 0.5f))
+      .filter(_ < 5.0e6f)
+      .map(_ + 0.25f)
+      .zip(zipSrc)
+      .map((a, b) => a + b)
+      .zipWithIndex
+      .filter((v, i) => i % 4 != 0)
+      .map((v, i) => v - i)
+      .flatMap(x => FArray(x, x + 3.0f))
+      .filter(_ > 0.0f)
+      .foldLeft(0.0f)((acc, x) => acc + x)
+  }
+}

--- a/benchmarks/src/scala/farray/FloatInputs.scala
+++ b/benchmarks/src/scala/farray/FloatInputs.scala
@@ -1,0 +1,27 @@
+package farray
+
+import org.openjdk.jmh.annotations.{Param, Setup}
+
+/** Primitive-Float inputs — exercises FArray's specialized FloatArr path against the competitors. */
+abstract class FloatInputs extends CommonParams {
+  @Param(Array("0", "1", "10", "100", "1000", "10000", "100000"))
+  var size: Int = 1000
+
+  var listInput: List[Float] = _
+  var vectorInput: Vector[Float] = _
+  var iarrayInput: IArray[Float] = _
+  var farrayInput: FArray[Float] = _
+  var fs2ChunkInput: fs2.Chunk[Float] = _
+  var zioChunkInput: zio.Chunk[Float] = _
+
+  @Setup
+  def setup(): Unit = {
+    val arr = Array.tabulate(size)(i => i.toFloat)
+    listInput = arr.toList
+    vectorInput = arr.toVector
+    iarrayInput = IArray.tabulate(size)(i => i.toFloat)
+    farrayInput = FArray.tabulate(size)(i => i.toFloat)
+    fs2ChunkInput = fs2.Chunk.array(arr)
+    zioChunkInput = zio.Chunk.fromArray(arr)
+  }
+}

--- a/benchmarks/src/scala/farray/FuseProbeBenchmark.scala
+++ b/benchmarks/src/scala/farray/FuseProbeBenchmark.scala
@@ -1,0 +1,68 @@
+package farray
+
+import org.openjdk.jmh.annotations.Benchmark
+
+// Probe WHICH fuse cost hurts C2: a NO-flatMap pipeline (map/filter/zip/zipWithIndex only). If fused
+// beats eager here on C2, then flatMap's per-element IntArr alloc + intAt read is the culprit.
+class FuseProbeNoFlatMapBenchmark extends IntInputs {
+  @Benchmark def farrayEager(): Int = {
+    farrayInput
+      .filter(_ % 3 != 0)
+      .map(_ * 2)
+      .filter(_ % 2 == 0)
+      .map(_ - 7)
+      .zip(farrayInput.map(_ + 100))
+      .map((a, b) => a + b)
+      .zipWithIndex
+      .filter((v, i) => (v + i) % 4 != 0)
+      .map((v, i) => v - i)
+      .filter(_ > 0)
+      .foldLeft(0)(_ + _)
+  }
+  @Benchmark def farrayFused(): Int = {
+    val zipSrc = farrayInput.map(_ + 100)
+    farrayInput.fuse
+      .filter(_ % 3 != 0)
+      .map(_ * 2)
+      .filter(_ % 2 == 0)
+      .map(_ - 7)
+      .zip(zipSrc)
+      .map((a, b) => a + b)
+      .zipWithIndex
+      .filter((v, i) => (v + i) % 4 != 0)
+      .map((v, i) => v - i)
+      .filter(_ > 0)
+      .foldLeft(0)(_ + _)
+  }
+}
+
+// Probe the OTHER extreme: ONLY flatMaps + a fold (no zip/zipWithIndex). Isolates the flatMap inner cost.
+// One class PER element-kind (Int/Long/Double/Ref) to prove the inline `${K}Arr` leaf fast-path in
+// `loopOver` covers EVERY kind, not just Int — the inner FArray each flatMap builds is of that kind.
+class FuseProbeFlatMapOnlyBenchmark extends IntInputs {
+  @Benchmark def farrayEager(): Int =
+    farrayInput.flatMap(x => FArray(x, x + 1)).flatMap(x => FArray(x, x ^ 5)).flatMap(x => FArray(x, x + 3)).foldLeft(0)(_ + _)
+  @Benchmark def farrayFused(): Int =
+    farrayInput.fuse.flatMap(x => FArray(x, x + 1)).flatMap(x => FArray(x, x ^ 5)).flatMap(x => FArray(x, x + 3)).foldLeft(0)(_ + _)
+}
+
+class FuseProbeFlatMapLongBenchmark extends IntInputs {
+  @Benchmark def farrayEager(): Long =
+    farrayInput.flatMap(x => FArray(x.toLong, x.toLong + 1)).flatMap(y => FArray(y, y ^ 5L)).flatMap(y => FArray(y, y + 3)).foldLeft(0L)(_ + _)
+  @Benchmark def farrayFused(): Long =
+    farrayInput.fuse.flatMap(x => FArray(x.toLong, x.toLong + 1)).flatMap(y => FArray(y, y ^ 5L)).flatMap(y => FArray(y, y + 3)).foldLeft(0L)(_ + _)
+}
+
+class FuseProbeFlatMapDoubleBenchmark extends IntInputs {
+  @Benchmark def farrayEager(): Double =
+    farrayInput.flatMap(x => FArray(x.toDouble, x + 1.0)).flatMap(y => FArray(y, y * 2.0)).flatMap(y => FArray(y, y - 3.0)).foldLeft(0.0)(_ + _)
+  @Benchmark def farrayFused(): Double =
+    farrayInput.fuse.flatMap(x => FArray(x.toDouble, x + 1.0)).flatMap(y => FArray(y, y * 2.0)).flatMap(y => FArray(y, y - 3.0)).foldLeft(0.0)(_ + _)
+}
+
+class FuseProbeFlatMapRefBenchmark extends Inputs {
+  @Benchmark def farrayEager(): Int =
+    farrayInput.flatMap(s => FArray(s, s + "a")).flatMap(s => FArray(s, s + "b")).flatMap(s => FArray(s, s + "c")).foldLeft(0)(_ + _.length)
+  @Benchmark def farrayFused(): Int =
+    farrayInput.fuse.flatMap(s => FArray(s, s + "a")).flatMap(s => FArray(s, s + "b")).flatMap(s => FArray(s, s + "c")).foldLeft(0)(_ + _.length)
+}

--- a/benchmarks/src/scala/farray/IntAllOpsBench.scala
+++ b/benchmarks/src/scala/farray/IntAllOpsBench.scala
@@ -1,0 +1,127 @@
+package farray
+
+import org.openjdk.jmh.annotations.Benchmark
+
+// ONE long, mixed-stage Int pipeline run apples-to-apples across all 6 collections + a fused FArray
+// variant. flatMap·filter·map·flatMap·filter·map · zip·map · zipWithIndex · filter·map·flatMap·filter · fold.
+// Every stage exists on every collection; every lambda is distinct; the chain is long enough that each
+// eager stage allocates a fresh intermediate (List/Vector box every Int; IArray/Chunk box once their
+// shared map/fold goes megamorphic) while FArray stays an unboxed IntArr the whole way, and `.fuse`
+// runs it in ONE pass with no intermediate collections.
+class IntAllOpsBench extends IntInputs {
+
+  @Benchmark def list(): Int = listInput
+    .flatMap(x => List(x, x + 1))
+    .filter(_ % 3 != 0)
+    .map(_ * 2)
+    .flatMap(x => List(x, x ^ 5))
+    .filter(_ % 2 == 0)
+    .map(_ - 7)
+    .zip(listInput.map(_ + 100))
+    .map((a, b) => a + b)
+    .zipWithIndex
+    .filter((v, i) => (v + i) % 4 != 0)
+    .map((v, i) => v - i)
+    .flatMap(x => List(x, x + 3))
+    .filter(_ > 0)
+    .foldLeft(0)((acc, x) => acc + x)
+
+  @Benchmark def vector(): Int = vectorInput
+    .flatMap(x => Vector(x, x + 1))
+    .filter(_ % 3 != 0)
+    .map(_ * 2)
+    .flatMap(x => Vector(x, x ^ 5))
+    .filter(_ % 2 == 0)
+    .map(_ - 7)
+    .zip(vectorInput.map(_ + 100))
+    .map((a, b) => a + b)
+    .zipWithIndex
+    .filter((v, i) => (v + i) % 4 != 0)
+    .map((v, i) => v - i)
+    .flatMap(x => Vector(x, x + 3))
+    .filter(_ > 0)
+    .foldLeft(0)((acc, x) => acc + x)
+
+  @Benchmark def iarray(): Int = iarrayInput
+    .flatMap(x => IArray(x, x + 1))
+    .filter(_ % 3 != 0)
+    .map(_ * 2)
+    .flatMap(x => IArray(x, x ^ 5))
+    .filter(_ % 2 == 0)
+    .map(_ - 7)
+    .zip(iarrayInput.map(_ + 100))
+    .map((a, b) => a + b)
+    .zipWithIndex
+    .filter((v, i) => (v + i) % 4 != 0)
+    .map((v, i) => v - i)
+    .flatMap(x => IArray(x, x + 3))
+    .filter(_ > 0)
+    .foldLeft(0)((acc, x) => acc + x)
+
+  @Benchmark def farray(): Int = farrayInput
+    .flatMap(x => FArray(x, x + 1))
+    .filter(_ % 3 != 0)
+    .map(_ * 2)
+    .flatMap(x => FArray(x, x ^ 5))
+    .filter(_ % 2 == 0)
+    .map(_ - 7)
+    .zip(farrayInput.map(_ + 100))
+    .map((a, b) => a + b)
+    .zipWithIndex
+    .filter((v, i) => (v + i) % 4 != 0)
+    .map((v, i) => v - i)
+    .flatMap(x => FArray(x, x + 3))
+    .filter(_ > 0)
+    .foldLeft(0)((acc, x) => acc + x)
+
+  @Benchmark def fs2chunk(): Int = fs2ChunkInput
+    .flatMap(x => fs2.Chunk(x, x + 1))
+    .filter(_ % 3 != 0)
+    .map(_ * 2)
+    .flatMap(x => fs2.Chunk(x, x ^ 5))
+    .filter(_ % 2 == 0)
+    .map(_ - 7)
+    .zip(fs2ChunkInput.map(_ + 100))
+    .map((a, b) => a + b)
+    .zipWithIndex
+    .filter((v, i) => (v + i) % 4 != 0)
+    .map((v, i) => v - i)
+    .flatMap(x => fs2.Chunk(x, x + 3))
+    .filter(_ > 0)
+    .foldLeft(0)((acc, x) => acc + x)
+
+  @Benchmark def ziochunk(): Int = zioChunkInput
+    .flatMap(x => zio.Chunk(x, x + 1))
+    .filter(_ % 3 != 0)
+    .map(_ * 2)
+    .flatMap(x => zio.Chunk(x, x ^ 5))
+    .filter(_ % 2 == 0)
+    .map(_ - 7)
+    .zip(zioChunkInput.map(_ + 100))
+    .map((a, b) => a + b)
+    .zipWithIndex
+    .filter((v, i) => (v + i) % 4 != 0)
+    .map((v, i) => v - i)
+    .flatMap(x => zio.Chunk(x, x + 3))
+    .filter(_ > 0)
+    .foldLeft(0)((acc, x) => acc + x)
+
+  @Benchmark def farrayFused(): Int = {
+    val zipSrc = farrayInput.map(_ + 100)
+    farrayInput.fuse
+      .flatMap(x => FArray(x, x + 1))
+      .filter(_ % 3 != 0)
+      .map(_ * 2)
+      .flatMap(x => FArray(x, x ^ 5))
+      .filter(_ % 2 == 0)
+      .map(_ - 7)
+      .zip(zipSrc)
+      .map((a, b) => a + b)
+      .zipWithIndex
+      .filter((v, i) => (v + i) % 4 != 0)
+      .map((v, i) => v - i)
+      .flatMap(x => FArray(x, x + 3))
+      .filter(_ > 0)
+      .foldLeft(0)((acc, x) => acc + x)
+  }
+}

--- a/benchmarks/src/scala/farray/LongAllOpsBench.scala
+++ b/benchmarks/src/scala/farray/LongAllOpsBench.scala
@@ -1,0 +1,127 @@
+package farray
+
+import org.openjdk.jmh.annotations.Benchmark
+
+// ONE long, mixed-stage Long pipeline run apples-to-apples across all 6 collections + a fused FArray
+// variant. flatMap·filter·map·flatMap·filter·map · zip·map · zipWithIndex · filter·map·flatMap·filter · fold.
+// Every stage exists on every collection; every lambda is distinct; the chain is long enough that each
+// eager stage allocates a fresh intermediate (List/Vector box every Long; IArray/Chunk box once their
+// shared map/fold goes megamorphic) while FArray stays an unboxed LongArr the whole way, and `.fuse`
+// runs it in ONE pass with no intermediate collections.
+class LongAllOpsBench extends LongInputs {
+
+  @Benchmark def list(): Long = listInput
+    .flatMap(x => List(x, x + 1L))
+    .filter(_ % 3L != 0L)
+    .map(_ * 2L)
+    .flatMap(x => List(x, x ^ 5L))
+    .filter(_ % 2L == 0L)
+    .map(_ - 7L)
+    .zip(listInput.map(_ + 100L))
+    .map((a, b) => a + b)
+    .zipWithIndex
+    .filter((v, i) => (v + i) % 4L != 0L)
+    .map((v, i) => v - i)
+    .flatMap(x => List(x, x + 3L))
+    .filter(_ > 0L)
+    .foldLeft(0L)((acc, x) => acc + x)
+
+  @Benchmark def vector(): Long = vectorInput
+    .flatMap(x => Vector(x, x + 1L))
+    .filter(_ % 3L != 0L)
+    .map(_ * 2L)
+    .flatMap(x => Vector(x, x ^ 5L))
+    .filter(_ % 2L == 0L)
+    .map(_ - 7L)
+    .zip(vectorInput.map(_ + 100L))
+    .map((a, b) => a + b)
+    .zipWithIndex
+    .filter((v, i) => (v + i) % 4L != 0L)
+    .map((v, i) => v - i)
+    .flatMap(x => Vector(x, x + 3L))
+    .filter(_ > 0L)
+    .foldLeft(0L)((acc, x) => acc + x)
+
+  @Benchmark def iarray(): Long = iarrayInput
+    .flatMap(x => IArray(x, x + 1L))
+    .filter(_ % 3L != 0L)
+    .map(_ * 2L)
+    .flatMap(x => IArray(x, x ^ 5L))
+    .filter(_ % 2L == 0L)
+    .map(_ - 7L)
+    .zip(iarrayInput.map(_ + 100L))
+    .map((a, b) => a + b)
+    .zipWithIndex
+    .filter((v, i) => (v + i) % 4L != 0L)
+    .map((v, i) => v - i)
+    .flatMap(x => IArray(x, x + 3L))
+    .filter(_ > 0L)
+    .foldLeft(0L)((acc, x) => acc + x)
+
+  @Benchmark def farray(): Long = farrayInput
+    .flatMap(x => FArray(x, x + 1L))
+    .filter(_ % 3L != 0L)
+    .map(_ * 2L)
+    .flatMap(x => FArray(x, x ^ 5L))
+    .filter(_ % 2L == 0L)
+    .map(_ - 7L)
+    .zip(farrayInput.map(_ + 100L))
+    .map((a, b) => a + b)
+    .zipWithIndex
+    .filter((v, i) => (v + i) % 4L != 0L)
+    .map((v, i) => v - i)
+    .flatMap(x => FArray(x, x + 3L))
+    .filter(_ > 0L)
+    .foldLeft(0L)((acc, x) => acc + x)
+
+  @Benchmark def fs2chunk(): Long = fs2ChunkInput
+    .flatMap(x => fs2.Chunk(x, x + 1L))
+    .filter(_ % 3L != 0L)
+    .map(_ * 2L)
+    .flatMap(x => fs2.Chunk(x, x ^ 5L))
+    .filter(_ % 2L == 0L)
+    .map(_ - 7L)
+    .zip(fs2ChunkInput.map(_ + 100L))
+    .map((a, b) => a + b)
+    .zipWithIndex
+    .filter((v, i) => (v + i) % 4L != 0L)
+    .map((v, i) => v - i)
+    .flatMap(x => fs2.Chunk(x, x + 3L))
+    .filter(_ > 0L)
+    .foldLeft(0L)((acc, x) => acc + x)
+
+  @Benchmark def ziochunk(): Long = zioChunkInput
+    .flatMap(x => zio.Chunk(x, x + 1L))
+    .filter(_ % 3L != 0L)
+    .map(_ * 2L)
+    .flatMap(x => zio.Chunk(x, x ^ 5L))
+    .filter(_ % 2L == 0L)
+    .map(_ - 7L)
+    .zip(zioChunkInput.map(_ + 100L))
+    .map((a, b) => a + b)
+    .zipWithIndex
+    .filter((v, i) => (v + i) % 4L != 0L)
+    .map((v, i) => v - i)
+    .flatMap(x => zio.Chunk(x, x + 3L))
+    .filter(_ > 0L)
+    .foldLeft(0L)((acc, x) => acc + x)
+
+  @Benchmark def farrayFused(): Long = {
+    val zipSrc = farrayInput.map(_ + 100L)
+    farrayInput.fuse
+      .flatMap(x => FArray(x, x + 1L))
+      .filter(_ % 3L != 0L)
+      .map(_ * 2L)
+      .flatMap(x => FArray(x, x ^ 5L))
+      .filter(_ % 2L == 0L)
+      .map(_ - 7L)
+      .zip(zipSrc)
+      .map((a, b) => a + b)
+      .zipWithIndex
+      .filter((v, i) => (v + i) % 4L != 0L)
+      .map((v, i) => v - i)
+      .flatMap(x => FArray(x, x + 3L))
+      .filter(_ > 0L)
+      .foldLeft(0L)((acc, x) => acc + x)
+  }
+}

--- a/benchmarks/src/scala/farray/LongInputs.scala
+++ b/benchmarks/src/scala/farray/LongInputs.scala
@@ -1,0 +1,27 @@
+package farray
+
+import org.openjdk.jmh.annotations.{Param, Setup}
+
+/** Primitive-Long inputs — exercises FArray's specialized LongArr path against the competitors. */
+abstract class LongInputs extends CommonParams {
+  @Param(Array("0", "1", "10", "100", "1000", "10000", "100000"))
+  var size: Int = 1000
+
+  var listInput: List[Long] = _
+  var vectorInput: Vector[Long] = _
+  var iarrayInput: IArray[Long] = _
+  var farrayInput: FArray[Long] = _
+  var fs2ChunkInput: fs2.Chunk[Long] = _
+  var zioChunkInput: zio.Chunk[Long] = _
+
+  @Setup
+  def setup(): Unit = {
+    val arr = Array.tabulate(size)(i => i.toLong)
+    listInput = arr.toList
+    vectorInput = arr.toVector
+    iarrayInput = IArray.tabulate(size)(i => i.toLong)
+    farrayInput = FArray.tabulate(size)(i => i.toLong)
+    fs2ChunkInput = fs2.Chunk.array(arr)
+    zioChunkInput = zio.Chunk.fromArray(arr)
+  }
+}

--- a/benchmarks/src/scala/farray/LongMixedPipelineBenchmark.scala
+++ b/benchmarks/src/scala/farray/LongMixedPipelineBenchmark.scala
@@ -1,0 +1,145 @@
+package farray
+
+import org.openjdk.jmh.annotations.Benchmark
+
+// A LONG, mixed-stage pipeline run apples-to-apples across all 6 collections. flatMap (×2) · filter ·
+// map · zip · zipWithIndex · filter · map · flatMap · filter · foldLeft. Every op exists on every
+// collection (no `collect`/`takeWhile`, which fs2/zio lack), every lambda is distinct (no CSE), and the
+// pipeline is long enough that (a) each stage allocates a fresh intermediate collection and (b) the
+// enclosing method is large. This probes BOTH axes of the hypothesis at once: per-element boxing of the
+// primitive payload (Int) AND the intermediate-allocation / inlining-budget cost of a realistic chain.
+//
+// Each collection runs the IDENTICAL logical transform; the only differences are forced by API shape
+// (zip tuple types). The result is a single Int folded out, so the whole chain is consumed.
+class LongMixedPipelineIntBenchmark extends IntInputs {
+
+  @Benchmark def list(): Int = {
+    listInput
+      .flatMap(x => List(x, x + 1))
+      .filter(_ % 3 != 0)
+      .map(_ * 2)
+      .flatMap(x => List(x, x ^ 5))
+      .filter(_ % 2 == 0)
+      .map(_ - 7)
+      .zip(listInput.map(_ + 100))
+      .map((a, b) => a + b)
+      .zipWithIndex
+      .filter((v, i) => (v + i) % 4 != 0)
+      .map((v, i) => v - i)
+      .flatMap(x => List(x, x + 3))
+      .filter(_ > 0)
+      .foldLeft(0)(_ + _)
+  }
+
+  @Benchmark def vector(): Int = {
+    vectorInput
+      .flatMap(x => Vector(x, x + 1))
+      .filter(_ % 3 != 0)
+      .map(_ * 2)
+      .flatMap(x => Vector(x, x ^ 5))
+      .filter(_ % 2 == 0)
+      .map(_ - 7)
+      .zip(vectorInput.map(_ + 100))
+      .map((a, b) => a + b)
+      .zipWithIndex
+      .filter((v, i) => (v + i) % 4 != 0)
+      .map((v, i) => v - i)
+      .flatMap(x => Vector(x, x + 3))
+      .filter(_ > 0)
+      .foldLeft(0)(_ + _)
+  }
+
+  @Benchmark def iarray(): Int = {
+    iarrayInput
+      .flatMap(x => IArray(x, x + 1))
+      .filter(_ % 3 != 0)
+      .map(_ * 2)
+      .flatMap(x => IArray(x, x ^ 5))
+      .filter(_ % 2 == 0)
+      .map(_ - 7)
+      .zip(iarrayInput.map(_ + 100))
+      .map((a, b) => a + b)
+      .zipWithIndex
+      .filter((v, i) => (v + i) % 4 != 0)
+      .map((v, i) => v - i)
+      .flatMap(x => IArray(x, x + 3))
+      .filter(_ > 0)
+      .foldLeft(0)(_ + _)
+  }
+
+  @Benchmark def farray(): Int = {
+    farrayInput
+      .flatMap(x => FArray(x, x + 1))
+      .filter(_ % 3 != 0)
+      .map(_ * 2)
+      .flatMap(x => FArray(x, x ^ 5))
+      .filter(_ % 2 == 0)
+      .map(_ - 7)
+      .zip(farrayInput.map(_ + 100))
+      .map((a, b) => a + b)
+      .zipWithIndex
+      .filter((v, i) => (v + i) % 4 != 0)
+      .map((v, i) => v - i)
+      .flatMap(x => FArray(x, x + 3))
+      .filter(_ > 0)
+      .foldLeft(0)(_ + _)
+  }
+
+  // The SAME logical pipeline through FArray's `fuse` — one pass, no intermediate collections, no
+  // Function1, unboxed Int throughout. Same stages as `farray` above. The `zip` source is hoisted to a
+  // `val` so the fuse macro sees a simple reference (it reads the `that` argument off the AST).
+  @Benchmark def farrayFused(): Int = {
+    val zipSrc = farrayInput.map(_ + 100)
+    farrayInput.fuse
+      .flatMap(x => FArray(x, x + 1))
+      .filter(_ % 3 != 0)
+      .map(_ * 2)
+      .flatMap(x => FArray(x, x ^ 5))
+      .filter(_ % 2 == 0)
+      .map(_ - 7)
+      .zip(zipSrc)
+      .map((a, b) => a + b)
+      .zipWithIndex
+      .filter((v, i) => (v + i) % 4 != 0)
+      .map((v, i) => v - i)
+      .flatMap(x => FArray(x, x + 3))
+      .filter(_ > 0)
+      .foldLeft(0)(_ + _)
+  }
+
+  @Benchmark def fs2chunk(): Int = {
+    fs2ChunkInput
+      .flatMap(x => fs2.Chunk(x, x + 1))
+      .filter(_ % 3 != 0)
+      .map(_ * 2)
+      .flatMap(x => fs2.Chunk(x, x ^ 5))
+      .filter(_ % 2 == 0)
+      .map(_ - 7)
+      .zip(fs2ChunkInput.map(_ + 100))
+      .map((a, b) => a + b)
+      .zipWithIndex
+      .filter((v, i) => (v + i) % 4 != 0)
+      .map((v, i) => v - i)
+      .flatMap(x => fs2.Chunk(x, x + 3))
+      .filter(_ > 0)
+      .foldLeft(0)(_ + _)
+  }
+
+  @Benchmark def ziochunk(): Int = {
+    zioChunkInput
+      .flatMap(x => zio.Chunk(x, x + 1))
+      .filter(_ % 3 != 0)
+      .map(_ * 2)
+      .flatMap(x => zio.Chunk(x, x ^ 5))
+      .filter(_ % 2 == 0)
+      .map(_ - 7)
+      .zip(zioChunkInput.map(_ + 100))
+      .map((a, b) => a + b)
+      .zipWithIndex
+      .filter((v, i) => (v + i) % 4 != 0)
+      .map((v, i) => v - i)
+      .flatMap(x => zio.Chunk(x, x + 3))
+      .filter(_ > 0)
+      .foldLeft(0)(_ + _)
+  }
+}

--- a/benchmarks/src/scala/farray/ShortAllOpsBench.scala
+++ b/benchmarks/src/scala/farray/ShortAllOpsBench.scala
@@ -1,0 +1,127 @@
+package farray
+
+import org.openjdk.jmh.annotations.Benchmark
+
+// ONE long, mixed-stage Short pipeline run apples-to-apples across all 6 collections + a fused FArray
+// variant. flatMap·filter·map·flatMap·filter·map · zip·map · zipWithIndex · filter·map·flatMap·filter · fold.
+// Every stage exists on every collection; every lambda is distinct; the chain is long enough that each
+// eager stage allocates a fresh intermediate (List/Vector box every Short; IArray/Chunk box once their
+// shared map/fold goes megamorphic) while FArray stays an unboxed ShortArr the whole way, and `.fuse`
+// runs it in ONE pass with no intermediate collections.
+class ShortAllOpsBench extends ShortInputs {
+
+  @Benchmark def list(): Int = listInput
+    .flatMap(x => List(x, (x + 1).toShort))
+    .filter(_ % 3 != 0)
+    .map(s => (s * 2).toShort)
+    .flatMap(x => List(x, (x ^ 5).toShort))
+    .filter(_ % 2 == 0)
+    .map(s => (s - 7).toShort)
+    .zip(listInput.map(s => (s + 100).toShort))
+    .map((a, b) => (a + b).toShort)
+    .zipWithIndex
+    .filter((v, i) => (v + i) % 4 != 0)
+    .map((v, i) => (v - i).toShort)
+    .flatMap(x => List(x, (x + 3).toShort))
+    .filter(_ > 0)
+    .foldLeft(0)((acc, x) => acc + x)
+
+  @Benchmark def vector(): Int = vectorInput
+    .flatMap(x => Vector(x, (x + 1).toShort))
+    .filter(_ % 3 != 0)
+    .map(s => (s * 2).toShort)
+    .flatMap(x => Vector(x, (x ^ 5).toShort))
+    .filter(_ % 2 == 0)
+    .map(s => (s - 7).toShort)
+    .zip(vectorInput.map(s => (s + 100).toShort))
+    .map((a, b) => (a + b).toShort)
+    .zipWithIndex
+    .filter((v, i) => (v + i) % 4 != 0)
+    .map((v, i) => (v - i).toShort)
+    .flatMap(x => Vector(x, (x + 3).toShort))
+    .filter(_ > 0)
+    .foldLeft(0)((acc, x) => acc + x)
+
+  @Benchmark def iarray(): Int = iarrayInput
+    .flatMap(x => IArray(x, (x + 1).toShort))
+    .filter(_ % 3 != 0)
+    .map(s => (s * 2).toShort)
+    .flatMap(x => IArray(x, (x ^ 5).toShort))
+    .filter(_ % 2 == 0)
+    .map(s => (s - 7).toShort)
+    .zip(iarrayInput.map(s => (s + 100).toShort))
+    .map((a, b) => (a + b).toShort)
+    .zipWithIndex
+    .filter((v, i) => (v + i) % 4 != 0)
+    .map((v, i) => (v - i).toShort)
+    .flatMap(x => IArray(x, (x + 3).toShort))
+    .filter(_ > 0)
+    .foldLeft(0)((acc, x) => acc + x)
+
+  @Benchmark def farray(): Int = farrayInput
+    .flatMap(x => FArray(x, (x + 1).toShort))
+    .filter(_ % 3 != 0)
+    .map(s => (s * 2).toShort)
+    .flatMap(x => FArray(x, (x ^ 5).toShort))
+    .filter(_ % 2 == 0)
+    .map(s => (s - 7).toShort)
+    .zip(farrayInput.map(s => (s + 100).toShort))
+    .map((a, b) => (a + b).toShort)
+    .zipWithIndex
+    .filter((v, i) => (v + i) % 4 != 0)
+    .map((v, i) => (v - i).toShort)
+    .flatMap(x => FArray(x, (x + 3).toShort))
+    .filter(_ > 0)
+    .foldLeft(0)((acc, x) => acc + x)
+
+  @Benchmark def fs2chunk(): Int = fs2ChunkInput
+    .flatMap(x => fs2.Chunk(x, (x + 1).toShort))
+    .filter(_ % 3 != 0)
+    .map(s => (s * 2).toShort)
+    .flatMap(x => fs2.Chunk(x, (x ^ 5).toShort))
+    .filter(_ % 2 == 0)
+    .map(s => (s - 7).toShort)
+    .zip(fs2ChunkInput.map(s => (s + 100).toShort))
+    .map((a, b) => (a + b).toShort)
+    .zipWithIndex
+    .filter((v, i) => (v + i) % 4 != 0)
+    .map((v, i) => (v - i).toShort)
+    .flatMap(x => fs2.Chunk(x, (x + 3).toShort))
+    .filter(_ > 0)
+    .foldLeft(0)((acc, x) => acc + x)
+
+  @Benchmark def ziochunk(): Int = zioChunkInput
+    .flatMap(x => zio.Chunk(x, (x + 1).toShort))
+    .filter(_ % 3 != 0)
+    .map(s => (s * 2).toShort)
+    .flatMap(x => zio.Chunk(x, (x ^ 5).toShort))
+    .filter(_ % 2 == 0)
+    .map(s => (s - 7).toShort)
+    .zip(zioChunkInput.map(s => (s + 100).toShort))
+    .map((a, b) => (a + b).toShort)
+    .zipWithIndex
+    .filter((v, i) => (v + i) % 4 != 0)
+    .map((v, i) => (v - i).toShort)
+    .flatMap(x => zio.Chunk(x, (x + 3).toShort))
+    .filter(_ > 0)
+    .foldLeft(0)((acc, x) => acc + x)
+
+  @Benchmark def farrayFused(): Int = {
+    val zipSrc = farrayInput.map(s => (s + 100).toShort)
+    farrayInput.fuse
+      .flatMap(x => FArray(x, (x + 1).toShort))
+      .filter(_ % 3 != 0)
+      .map(s => (s * 2).toShort)
+      .flatMap(x => FArray(x, (x ^ 5).toShort))
+      .filter(_ % 2 == 0)
+      .map(s => (s - 7).toShort)
+      .zip(zipSrc)
+      .map((a, b) => (a + b).toShort)
+      .zipWithIndex
+      .filter((v, i) => (v + i) % 4 != 0)
+      .map((v, i) => (v - i).toShort)
+      .flatMap(x => FArray(x, (x + 3).toShort))
+      .filter(_ > 0)
+      .foldLeft(0)((acc, x) => acc + x)
+  }
+}

--- a/benchmarks/src/scala/farray/ShortInputs.scala
+++ b/benchmarks/src/scala/farray/ShortInputs.scala
@@ -1,0 +1,27 @@
+package farray
+
+import org.openjdk.jmh.annotations.{Param, Setup}
+
+/** Primitive-Short inputs — exercises FArray's specialized ShortArr path against the competitors. */
+abstract class ShortInputs extends CommonParams {
+  @Param(Array("0", "1", "10", "100", "1000", "10000", "100000"))
+  var size: Int = 1000
+
+  var listInput: List[Short] = _
+  var vectorInput: Vector[Short] = _
+  var iarrayInput: IArray[Short] = _
+  var farrayInput: FArray[Short] = _
+  var fs2ChunkInput: fs2.Chunk[Short] = _
+  var zioChunkInput: zio.Chunk[Short] = _
+
+  @Setup
+  def setup(): Unit = {
+    val arr = Array.tabulate(size)(i => i.toShort)
+    listInput = arr.toList
+    vectorInput = arr.toVector
+    iarrayInput = IArray.tabulate(size)(i => i.toShort)
+    farrayInput = FArray.tabulate(size)(i => i.toShort)
+    fs2ChunkInput = fs2.Chunk.array(arr)
+    zioChunkInput = zio.Chunk.fromArray(arr)
+  }
+}

--- a/codegen/src/scala/farray/GenCores.scala
+++ b/codegen/src/scala/farray/GenCores.scala
@@ -112,16 +112,24 @@ object GenCores extends BleepCodegenScript("GenCores") {
     def unbox(v: String): String = prim match { case Some(b) => b.from(v); case None => s"($v).asInstanceOf[$arr]" }
   }
 
-  // Start with the common numeric kinds + reference; add rows here to cover more primitives.
+  // Every JVM primitive kind + reference. The ops (map/foldLeft/filter/scan/…) specialize over ALL of these.
   val opKinds: List[Kind] = List(
     Kind("Int", "Int", "Int", "0", "I", Some(Box("java.lang.Integer", "Int"))),
     Kind("Long", "Long", "Long", "0L", "J", Some(Box("java.lang.Long", "Long"))),
     Kind("Double", "Double", "Double", "0.0", "D", Some(Box("java.lang.Double", "Double"))),
+    Kind("Float", "Float", "Float", "0.0f", "F", Some(Box("java.lang.Float", "Float"))),
+    Kind("Short", "Short", "Short", "0", "S", Some(Box("java.lang.Short", "Short"))),
+    Kind("Byte", "Byte", "Byte", "0", "B", Some(Box("java.lang.Byte", "Byte"))),
+    Kind("Char", "Char", "Char", "'\\u0000'", "C", Some(Box("java.lang.Character", "Char"))),
+    Kind("Boolean", "Boolean", "Boolean", "false", "Z", Some(Box("java.lang.Boolean", "Boolean"))),
     Kind("Ref", "Object", "AnyRef", "null", "L", None)
   )
 
-  /** the primitive kinds only (Int/Long/Double) — used e.g. for the Ref-element + primitive-accumulator folds. */
+  /** the primitive kinds only — used e.g. for the Ref-element + primitive-accumulator folds. */
   val primKinds: List[Kind] = opKinds.filter(_.isPrim)
+
+  /** primitive kinds that have a `scala.math.Numeric` (so sum/product/scan-of-numeric work). Char/Boolean do not. */
+  val numericKinds: List[Kind] = opKinds.filter(k => k.isPrim && k.name != "Char" && k.name != "Boolean")
 
   private val grow =
     "if (sp + 2 > stack.length) { val ns = stack.length * 2; stack = java.util.Arrays.copyOf(stack, ns); tail = java.util.Arrays.copyOf(tail, ns); isTail = java.util.Arrays.copyOf(isTail, ns) }"
@@ -719,7 +727,7 @@ object GenCores extends BleepCodegenScript("GenCores") {
           Out.Scalar("acc")
         )
     def productSpec(k: Kind): Trav = {
-      val one = k.name match { case "Long" => "1L"; case "Double" => "1.0"; case _ => "1" }
+      val one = k.name match { case "Long" => "1L"; case "Double" => "1.0"; case "Float" => "1.0f"; case _ => "1" }
       if k.prim.isDefined then
         Trav(k, Dir.Fwd, Body(e => s"acc *= $e", rawArray = true), List(Acc("acc", k.arr, one)), Exit.Never, Out.Scalar("acc.asInstanceOf[B]"))
       else
@@ -1273,17 +1281,22 @@ object GenCores extends BleepCodegenScript("GenCores") {
     // unboxed acc is boxed to B (== the input kind at runtime for a prim FArray) only at the boundary.
     def sumProductSurface(k: Kind, combine: (String, String) => String, seed: String, isProduct: Boolean): String = {
       val K = k.name
-      if !k.isPrim then {
-        // Ref input: cold cross-kind Reduce (acc is B, a Numeric object). Route through the SAME generic
-        // Ref-acc shared leaf method (reduceLeafFwdRefRef) with the accumulator BOXED to AnyRef — NO inlined
-        // leaf loop. `num` is the Numeric[B]; the element v is Object, wrapped to A then cast to B.
+      // Non-NUMERIC kinds (Ref input, and the prim kinds with no Numeric — Char/Boolean): route through the
+      // generic Numeric path (`num.plus`/`num.times` on B). The surface requires `Numeric[B]`, so a Char/Boolean
+      // `sum` never actually compiles at the use site — but the codegen branch must still typecheck, and this
+      // boxed-acc form does. (For Ref it's the real, cold path.)
+      if !k.isPrim || !numericKinds.exists(_.name == K) then {
         val numOp = if isProduct then "num.times" else "num.plus"
         val refSeed = if isProduct then "num.one" else "num.zero"
-        return s"reduceLeafFwdRefRef[AnyRef](xs, ($refSeed).asInstanceOf[AnyRef], (acc, v) => $numOp(acc.asInstanceOf[B], r.wrap(v.asInstanceOf[A]).asInstanceOf[B]).asInstanceOf[AnyRef]).asInstanceOf[B]"
+        val toB = if k.isPrim then s"${k.box("v")}.asInstanceOf[B]" else s"r.wrap(v.asInstanceOf[A]).asInstanceOf[B]"
+        return s"reduceLeafFwd${K}Ref[AnyRef](xs, ($refSeed).asInstanceOf[AnyRef], (acc, v) => $numOp(acc.asInstanceOf[B], $toB).asInstanceOf[AnyRef]).asInstanceOf[B]"
       }
-      // realize the unboxed `${K}To${K}Fold` SAM (acc stays a primitive) and CALL the shared leaf method —
-      // NO inlined leaf loop. The leaf method peels Empty/One/leaf and routes trees through Traversers.
-      s"reduceLeafFwd${K}${K}(xs, $seed, (acc, v) => ${combine("acc", "v")}).asInstanceOf[B]"
+      // NUMERIC prim: realize the unboxed `${K}To${K}Fold` SAM (acc stays a primitive) and CALL the shared leaf
+      // method — NO inlined leaf loop. The leaf method peels Empty/One/leaf and routes trees through Traversers.
+      // Short/Byte arithmetic WIDENS to Int in Scala (`short + short: Int`), so narrow the combine back to the
+      // SAM's element type for those kinds.
+      val narrow = (e: String) => K match { case "Short" => s"($e).toShort"; case "Byte" => s"($e).toByte"; case _ => e }
+      s"reduceLeafFwd${K}${K}(xs, $seed, (acc, v) => ${narrow(combine("acc", "v"))}).asInstanceOf[B]"
     }
     // count: Reduce whose combine folds a predicate into an Int. Only the Int input kind has a usable unboxed
     // self-kind shared leaf method (reduceLeafFwdIntInt); other prim inputs (Long/Double) and Ref would need
@@ -1302,7 +1315,7 @@ object GenCores extends BleepCodegenScript("GenCores") {
     val countV = dispatchA(k => countSurface(k))
     val sumV = dispatchA(k => sumProductSurface(k, (acc, e) => s"$acc + $e", k.dflt, isProduct = false))
     val productV = {
-      def one(k: Kind) = k.name match { case "Long" => "1L"; case "Double" => "1.0"; case _ => "1" }
+      def one(k: Kind) = k.name match { case "Long" => "1L"; case "Double" => "1.0"; case "Float" => "1.0f"; case _ => "1" }
       dispatchA(k => sumProductSurface(k, (acc, e) => s"$acc * $e", one(k), isProduct = true))
     }
     // HYBRID Scan surface (design §2.1/§5): summon the input kind I (outer) AND the accumulator kind Z (= B,
@@ -1588,8 +1601,12 @@ object GenCores extends BleepCodegenScript("GenCores") {
     // tuples. For primitive×primitive we name the stdlib @specialized Tuple2 directly (Tuple2$mcXY$sp), which
     // stores the two values unboxed — Scala 3 no longer picks it itself, so a uniform-int zip never boxes the
     // elements into Integers; only the tuple object is allocated.
+    // Scala only @specializes Tuple2 over Int/Long/Double/Char/Boolean (I/J/D/C/Z); Short/Byte/Float (S/B/F)
+    // have NO `Tuple2$mc..$sp`, so those prims must use the plain boxed Tuple2 (the tuple element boxes — a Scala
+    // stdlib limitation, not ours).
+    def tupleSpec(k: Kind): Boolean = Set("I", "J", "D", "C", "Z").contains(k.specCh)
     def mkT(ka: Kind, kb: Kind, v1: String, v2: String): String =
-      if (ka.isPrim && kb.isPrim) s"new scala.Tuple2$$mc${ka.specCh}${kb.specCh}$$sp($v1, $v2)"
+      if (ka.isPrim && kb.isPrim && tupleSpec(ka) && tupleSpec(kb)) s"new scala.Tuple2$$mc${ka.specCh}${kb.specCh}$$sp($v1, $v2)"
       else s"new scala.Tuple2(${ka.box(v1)}, ${kb.box(v2)})"
     val zipV = withErr(
       "summonFrom {\n" + opKinds
@@ -1605,8 +1622,8 @@ object GenCores extends BleepCodegenScript("GenCores") {
       "A"
     )
     def mkTIdx(ka: Kind, v: String, idx: String): String =
-      if (ka.isPrim) s"new scala.Tuple2$$mc${ka.specCh}I$$sp($v, $idx)"
-      else s"new scala.Tuple2($v, ${opKinds.head.box(idx)})" // index is Int
+      if (ka.isPrim && tupleSpec(ka)) s"new scala.Tuple2$$mc${ka.specCh}I$$sp($v, $idx)"
+      else s"new scala.Tuple2(${ka.box(v)}, ${opKinds.head.box(idx)})" // index is Int
     val zipIdxV = withErr(
       "summonFrom {\n" + opKinds
         .map { ka =>
@@ -2241,12 +2258,15 @@ object GenCores extends BleepCodegenScript("GenCores") {
   // For Ref input the element is Object: RefToRefFold<Z> { Z apply(Z acc, Object v); }.
 
   /** The Java element type for an input Kind (Int/Long/Double -> primitives; Ref -> Object). */
-  private def jelem(k: Kind): String = k.name match {
-    case "Int"    => "int"
-    case "Long"   => "long"
-    case "Double" => "double"
-    case _        => "Object"
-  }
+  /** the Java element type for a Kind: each primitive's `jt` (int/long/double/float/short/byte/char/boolean); Ref -> Object. */
+  private def jelem(k: Kind): String =
+    prims.find(_.name == k.name).map(_.jt).getOrElse("Object")
+
+  /** read a single boxed `Object` (from a deep non-leaf base's applyBoxed) cast to the element's Java type. For a
+    * primitive, cast to the wrapper and unbox via its `${jt}Value()`; for Ref the element IS Object (pass-through). */
+  private def fromBoxedK(k: Kind, expr: String): String = prims.find(_.name == k.name) match
+    case Some(p) => s"((${p.boxed}) $expr).${p.jt}Value()"
+    case None    => expr
 
   /** All reduce traversers (input-kind × Z-acc × direction) plus the fold function types. The prim self-kind unboxed fold (`${I}To${I}Fold`) is emitted only
     * for primitive input kinds; every input kind gets the generic ref-acc fold (`${I}ToRefFold<Z>`).
@@ -2732,13 +2752,9 @@ object GenCores extends BleepCodegenScript("GenCores") {
     */
   private def emitMainWalk(e: Emit, spec: WalkSpec, backward: Boolean): Unit = {
     val K = spec.K
-    // the Java element type for this input kind (Pad filler / Updated leaf-array element type).
-    val je = K match {
-      case "Int"    => "int"
-      case "Long"   => "long"
-      case "Double" => "double"
-      case _        => "Object"
-    }
+    // the Java element type for this input kind (Pad filler / Updated leaf-array element type): each primitive's
+    // jt; Ref -> Object.
+    val je = prims.find(_.name == K).map(_.jt).getOrElse("Object")
     // grow the single FBase[] child stack; a deferred Append/Prepend element rides as a ${K}One node.
     def ensureStack(): Unit = {
       e.open("if (stack == null)")
@@ -2919,12 +2935,7 @@ object GenCores extends BleepCodegenScript("GenCores") {
     val recur = if refAcc then s"reduce${other}${K}Ref" else s"reduce${other}${K}${K}"
     // Read a single boxed Object from a deep (non-leaf) base, cast to the element type. For prims the cast
     // unboxes via the boxed wrapper's value method; for Ref the element IS Object (pass-through).
-    def fromBoxed(expr: String): String = k.name match {
-      case "Int"    => s"((Integer) $expr).intValue()"
-      case "Long"   => s"((Long) $expr).longValue()"
-      case "Double" => s"((Double) $expr).doubleValue()"
-      case _        => expr
-    }
+    def fromBoxed(expr: String): String = fromBoxedK(k, expr)
 
     // a WHOLE-leaf run: loop on `a.length`, NOT leaf.length. HotSpot can prove the bound matches the array it
     // indexes (a JVM fact) and drops the per-element bounds check on `a[i]`, vectorizing the load — `leaf.length`
@@ -3059,12 +3070,7 @@ object GenCores extends BleepCodegenScript("GenCores") {
       e.line(s"out[o] = f.apply($elem);")
       e.line("o += 1;")
     }
-    def fromBoxed(expr: String): String = ki.name match {
-      case "Int"    => s"((Integer) $expr).intValue()"
-      case "Long"   => s"((Long) $expr).longValue()"
-      case "Double" => s"((Double) $expr).doubleValue()"
-      case _        => expr
-    }
+    def fromBoxed(expr: String): String = fromBoxedK(ki, expr)
     // a WHOLE-leaf run on a.length (HotSpot drops the bounds check — see the reduce leaf note). The cursor `o`
     // advances ascending in BOTH directions; only the READ index walks descending for the Bwd build.
     def runLeaf(arr: String): Unit = e.scope {
@@ -3169,12 +3175,7 @@ object GenCores extends BleepCodegenScript("GenCores") {
       e.line("o += 1;")
       e.close()
     }
-    def fromBoxed(expr: String): String = k.name match {
-      case "Int"    => s"((Integer) $expr).intValue()"
-      case "Long"   => s"((Long) $expr).longValue()"
-      case "Double" => s"((Double) $expr).doubleValue()"
-      case _        => expr
-    }
+    def fromBoxed(expr: String): String = fromBoxedK(k, expr)
     // a WHOLE-leaf run on a.length. The READ index walks descending for the Bwd filter; the cursor advances asc.
     def runLeaf(arr: String): Unit = e.scope {
       e.line(s"$je[] a = $arr;")
@@ -3280,12 +3281,7 @@ object GenCores extends BleepCodegenScript("GenCores") {
       e.line("ob += 1;")
       e.close()
     }
-    def fromBoxed(expr: String): String = k.name match {
-      case "Int"    => s"((Integer) $expr).intValue()"
-      case "Long"   => s"((Long) $expr).longValue()"
-      case "Double" => s"((Double) $expr).doubleValue()"
-      case _        => expr
-    }
+    def fromBoxed(expr: String): String = fromBoxedK(k, expr)
     def runLeaf(arr: String): Unit = e.scope {
       e.line(s"$je[] a = $arr;")
       if !backward then {
@@ -3386,12 +3382,7 @@ object GenCores extends BleepCodegenScript("GenCores") {
     val other = if backward then "Fwd" else "Bwd"
     val sig = s"static void foreach${dir}${K}(FBase root, ${K}Consumer f)"
     val recur = s"foreach${other}${K}"
-    def fromBoxed(expr: String): String = k.name match {
-      case "Int"    => s"((Integer) $expr).intValue()"
-      case "Long"   => s"((Long) $expr).longValue()"
-      case "Double" => s"((Double) $expr).doubleValue()"
-      case _        => expr
-    }
+    def fromBoxed(expr: String): String = fromBoxedK(k, expr)
     // a WHOLE-leaf run on a.length (HotSpot drops the bounds check — see the reduce leaf note).
     def runLeaf(arr: String): Unit = e.scope {
       e.line(s"$je[] a = $arr;")
@@ -3502,12 +3493,7 @@ object GenCores extends BleepCodegenScript("GenCores") {
     val recur = s"scan${dir}${if rev == "Rev" then "" else "Rev"}${K}${if refAcc then "Ref" else K}"
     // read the running acc (the previously-written output slot) — governed by the WRITE convention, NOT visit dir.
     val prevAcc = if !writeBackward then (if refAcc then "(Z) out[o - 1]" else "out[o - 1]") else (if refAcc then "(Z) out[o + 1]" else "out[o + 1]")
-    def fromBoxed(expr: String): String = k.name match {
-      case "Int"    => s"((Integer) $expr).intValue()"
-      case "Long"   => s"((Long) $expr).longValue()"
-      case "Double" => s"((Double) $expr).doubleValue()"
-      case _        => expr
-    }
+    def fromBoxed(expr: String): String = fromBoxedK(k, expr)
     // write one scanned element from a raw input element expr. Governed by the WRITE convention (writeBackward),
     // NOT the visit direction: scanLeft advances o up; scanRight advances o down — regardless of visit order.
     def writeElem(elem: String): Unit =
@@ -3619,12 +3605,7 @@ object GenCores extends BleepCodegenScript("GenCores") {
     val clampParam = if backward then "end" else "from"
     val sig = s"static int sc${dir}${K}(FBase root, int $clampParam, int cum, ${K}Pred p)"
     val recur = s"sc${other}${K}"
-    def fromBoxed(expr: String): String = k.name match {
-      case "Int"    => s"((Integer) $expr).intValue()"
-      case "Long"   => s"((Long) $expr).longValue()"
-      case "Double" => s"((Double) $expr).doubleValue()"
-      case _        => expr
-    }
+    def fromBoxed(expr: String): String = fromBoxedK(k, expr)
     // Scan a run of `count` elements whose backing array is `arr` with the run's FIRST element at array index
     // `base`. The run's global indices are [cum, cum+count) (Fwd) / (cum-count, cum] descending (Bwd). On a hit
     // `return` the global index (abandon the stack); else advance `cum` past the run. The predicate-in-condition
@@ -4192,8 +4173,8 @@ object GenCores extends BleepCodegenScript("GenCores") {
        |}
        |""".stripMargin
 
-  /** Ops-kinds (Int/Long/Double/Ref) for the per-kind lazy nodes that carry a primitive payload. */
-  private val padKinds = List(("Int", "int", "Integer"), ("Long", "long", "Long"), ("Double", "double", "Double"), ("Ref", "Object", ""))
+  /** Kinds for the per-kind lazy nodes that carry a payload: EVERY prim kind + Ref. */
+  private val padKinds: List[(String, String, String)] = prims.map(p => (p.name, p.jt, p.boxed)) :+ ("Ref", "Object", "")
 
   /** Kinds with a `${K}One` singleton: EVERY prim leaf kind + Ref. Every length-1 FArray is one of these, so a length-1 leaf/append/prepend/slice of any prim
     * kind canonicalizes to its own-kind One with no boxing.
@@ -4299,12 +4280,17 @@ object GenCores extends BleepCodegenScript("GenCores") {
     * element). `rev` flips order for ReverseNode.
     */
   private def hashing: String = {
-    def eh(p: Prim, e: String): String = p.name match
+    // the element-hash expression for a kind by NAME (the single source of truth for every node shape). Matches
+    // scala.runtime.Statics.##: Int/Short/Byte/Char hash to their widened value; Long/Double/Float/Boolean/Ref
+    // use the dedicated hashers.
+    def ehName(name: String, e: String): String = name match
       case "Long"    => s"scala.runtime.Statics.longHash($e)"
       case "Double"  => s"scala.runtime.Statics.doubleHash($e)"
       case "Float"   => s"scala.runtime.Statics.floatHash($e)"
       case "Boolean" => s"($e ? 1231 : 1237)"
+      case "Ref"     => s"scala.runtime.Statics.anyHash($e)"
       case _         => e // Int/Short/Byte/Char: ## is the (widened) value
+    def eh(p: Prim, e: String): String = ehName(p.name, e)
     val leafFill = prims
       .map(p =>
         s"""       |        if (node instanceof ${p.name}Arr a) { if (rev) for (int i = a.length - 1; i >= 0; i--) hs[pos++] = ${eh(
@@ -4331,33 +4317,19 @@ object GenCores extends BleepCodegenScript("GenCores") {
       .mkString("\n")
     val padFill = padKinds
       .map { case (name, _, _) =>
-        val fh = name match
-          case "Long"   => "scala.runtime.Statics.longHash(pad.filler)"
-          case "Double" => "scala.runtime.Statics.doubleHash(pad.filler)"
-          case "Ref"    => "scala.runtime.Statics.anyHash(pad.filler)"
-          case _        => "pad.filler"
+        val fh = ehName(name, "pad.filler")
         s"""       |        if (node instanceof ${name}Pad pad) { int extra = pad.length - pad.base.length; if (rev) { for (int i = 0; i < extra; i++) hs[pos++] = $fh; return fill(pad.base, true, hs, pos); } else { pos = fill(pad.base, false, hs, pos); for (int i = 0; i < extra; i++) hs[pos++] = $fh; return pos; } }"""
       }
       .mkString("\n")
     val updatedFill = padKinds
       .map { case (name, _, _) =>
-        val eh2 = name match
-          case "Long"   => "scala.runtime.Statics.longHash(u.elem)"
-          case "Double" => "scala.runtime.Statics.doubleHash(u.elem)"
-          case "Ref"    => "scala.runtime.Statics.anyHash(u.elem)"
-          case _        => "u.elem"
+        val eh2 = ehName(name, "u.elem")
         s"""       |        if (node instanceof ${name}Updated u) { int start = pos; pos = fill(u.base, rev, hs, pos); hs[rev ? (start + u.length - 1 - u.index) : (start + u.index)] = $eh2; return pos; }"""
       }
       .mkString("\n")
     val oneFill = oneKinds
       .map { case (name, _, _) =>
-        val eh2 = name match
-          case "Long"    => "scala.runtime.Statics.longHash(o.elem)"
-          case "Double"  => "scala.runtime.Statics.doubleHash(o.elem)"
-          case "Float"   => "scala.runtime.Statics.floatHash(o.elem)"
-          case "Boolean" => "(o.elem ? 1231 : 1237)"
-          case "Ref"     => "scala.runtime.Statics.anyHash(o.elem)"
-          case _         => "o.elem"
+        val eh2 = ehName(name, "o.elem")
         s"""       |        if (node instanceof ${name}One o) { hs[pos] = $eh2; return pos + 1; }"""
       }
       .mkString("\n")

--- a/codegen/src/scala/farray/GenCores.scala
+++ b/codegen/src/scala/farray/GenCores.scala
@@ -2262,8 +2262,9 @@ object GenCores extends BleepCodegenScript("GenCores") {
   private def jelem(k: Kind): String =
     prims.find(_.name == k.name).map(_.jt).getOrElse("Object")
 
-  /** read a single boxed `Object` (from a deep non-leaf base's applyBoxed) cast to the element's Java type. For a
-    * primitive, cast to the wrapper and unbox via its `${jt}Value()`; for Ref the element IS Object (pass-through). */
+  /** read a single boxed `Object` (from a deep non-leaf base's applyBoxed) cast to the element's Java type. For a primitive, cast to the wrapper and unbox via
+    * its `${jt}Value()`; for Ref the element IS Object (pass-through).
+    */
   private def fromBoxedK(k: Kind, expr: String): String = prims.find(_.name == k.name) match
     case Some(p) => s"((${p.boxed}) $expr).${p.jt}Value()"
     case None    => expr

--- a/farray/src/scala/farray/FuseMacro.scala
+++ b/farray/src/scala/farray/FuseMacro.scala
@@ -197,6 +197,56 @@ object FuseMacro:
       Term.betaReduce(app).getOrElse(app)
     def applyLambda(fn: Term, arg: Term): Term = applyN(fn, List(arg))
 
+    /** If `body` is a LITERAL fixed-arity `FArray(e0, e1, …)` construction (which inline-expands to a Block that
+      * allocates a `${K}Arr` + backing array), return the element expressions `[e0, e1, …]` so a flatMap can splat
+      * them downstream with NO array allocation. The expanded shape (any leaf kind) is:
+      *   Block( ValDef("out", new Array[K](n)) :: out.update(0,e0) :: out.update(1,e1) :: … ,
+      *          new ${K}Arr(out, n) )
+      * wrapped in `Inlined`/`Typed`/`TypeApply(_, "$asInstanceOf$")`. Match it structurally (peel the wrappers,
+      * confirm the result is `new …Arr(<out>, _)`, then read the `<out>.update(i, e_i)` stores in index order). A
+      * non-literal body (variable `FArray`, a `range`/`tabulate`, an empty/1-elem special-case, …) returns None. */
+    def literalArrayElems(body: Term): Option[List[Term]] =
+      // peel asInstanceOf / Typed / single-expr Inlined wrappers WITHOUT collapsing a stmt-bearing Block.
+      def peel(t: Term): Term = t match
+        case TypeApply(Select(inner, "$asInstanceOf$"), _) => peel(inner)
+        case TypeApply(Select(inner, "asInstanceOf"), _)   => peel(inner)
+        case Typed(inner, _)                               => peel(inner)
+        case Inlined(_, Nil, inner)                         => peel(inner)
+        case Inlined(_, bindings, inner) if bindings.forall(_.isInstanceOf[ValDef]) => peel(inner)
+        case _                                             => t
+      peel(body) match
+        case Block(stmts, last) =>
+          // the result must be `new ${K}Arr(outIdent, lenLit)`; capture the `out` symbol. PRIMITIVE leaves only
+          // (IntArr/LongArr/DoubleArr): their stored element exprs are clean `Typed(e, K)` we can re-splice
+          // straight downstream. The Ref leaf (RefArr) wraps each element in `(e: A).asInstanceOf[Object]`, which
+          // does not re-splice cleanly AND has no boxing win to recover (Ref was already a tie) — skip it.
+          val primArr = Set("IntArr", "LongArr", "DoubleArr")
+          val outName: Option[String] = peel(last) match
+            case Apply(Select(New(tp), "<init>"), List(outRef, _)) if primArr.contains(tp.tpe.typeSymbol.name) =>
+              outRef match { case Ident(nm) => Some(nm); case _ => None }
+            case _ => None
+          outName.flatMap { nm =>
+            // collect `nm.update(idx, elem)` stores; require they are exactly indices 0..k-1 and that `nm` is a
+            // fresh `new Array[…](k)` local (so we are sure it is a self-contained literal, not an aliased array).
+            val sizeOpt: Option[Int] = stmts.collectFirst {
+              case ValDef(n, _, Some(rhs)) if n == nm =>
+                peel(rhs) match
+                  case Apply(TypeApply(Select(New(_), "<init>"), _), List(Literal(IntConstant(k)))) => k
+                  case Apply(Select(New(_), "<init>"), List(Literal(IntConstant(k))))               => k
+                  case _                                                                            => -1
+            }
+            // strip the `Typed(e, K)` ascription the prim store carries — `e` itself is the clean element expr.
+            def stripTyped(t: Term): Term = t match { case Typed(e, _) => stripTyped(e); case _ => t }
+            val updates: List[(Int, Term)] = stmts.collect {
+              case Apply(Select(Ident(n), "update"), List(Literal(IntConstant(idx)), elem)) if n == nm => (idx, stripTyped(elem))
+            }
+            sizeOpt match
+              case Some(k) if k >= 0 && updates.length == k && updates.map(_._1).sorted == (0 until k).toList =>
+                Some(updates.sortBy(_._1).map(_._2))
+              case _ => None
+          }
+        case _ => None
+
     /** build the identity lambda `(a: A) => a` for element type `tpe` (used as the key of largest/smallest). */
     def identityLambda(tpe: TypeRepr): Term = tpe.asType match
       case '[a] => '{ (x: a) => x }.asTerm
@@ -865,9 +915,21 @@ object FuseMacro:
           buildSegment(seg.map(_._1), srcShape(cur))(finalShape => ctx.consumeShape.get(finalShape))
         else buildSegment(seg.map(_._1), srcShape(cur))(finalShape => readShape(finalShape)(t => buildBody(rest, t, ctx)))
       case (FlatMapS(f, bTpe), _) :: rest =>
-        // open a nested loop over f(cur): everything downstream runs inside it.
-        val inner: Expr[FBase] = '{ ${ applyLambda(f, cur).asExpr }.asInstanceOf[FBase] }
-        loopOver(inner, kindOf(bTpe), bTpe, rest, ctx).asTerm
+        val innerBody = applyLambda(f, cur)
+        // FAST PATH: a literal `FArray(e0, e1, …)` flatMap body inline-expands to a Block that allocates a
+        // fresh `${K}Arr` (a `new Array` + element stores) PER ELEMENT. The JIT eliminates the `${K}Arr`
+        // wrapper but NOT the backing array (a small array read with a variable loop index is not scalar-
+        // replaceable on HotSpot) — so each such flatMap leaks one array/elem (measured: 1.68 MB/op, the C2
+        // flatMap floor). If the body is exactly that literal form, SPLAT the element exprs straight into the
+        // downstream segment — `buildBody(rest, e_k)` per element — with NO array, NO `${K}Arr`, NO inner loop.
+        // 0 alloc; measured ~3x faster than the array form on C2 (49k vs 16k ops/s) and beats eager.
+        literalArrayElems(innerBody) match
+          case Some(elems) =>
+            Block(elems.map(e => buildBody(rest, e, ctx)), '{ () }.asTerm)
+          case None =>
+            // general flatMap: open a nested loop over f(cur); everything downstream runs inside it.
+            val inner: Expr[FBase] = '{ ${ innerBody.asExpr }.asInstanceOf[FBase] }
+            loopOver(inner, kindOf(bTpe), bTpe, rest, ctx).asTerm
       case (CollectS(pf, bTpe), _) :: rest =>
         // inline the PartialFunction's match into the loop: each real case continues downstream, the synthetic
         // `case _ => default(x)` fallthrough becomes a skip. So collect is filter+map+match fused, no PF object.

--- a/farray/src/scala/farray/FuseMacro.scala
+++ b/farray/src/scala/farray/FuseMacro.scala
@@ -202,23 +202,21 @@ object FuseMacro:
       Term.betaReduce(app).getOrElse(app)
     def applyLambda(fn: Term, arg: Term): Term = applyN(fn, List(arg))
 
-    /** If `body` is a LITERAL fixed-arity `FArray(e0, e1, …)` construction (which inline-expands to a Block that
-      * allocates a `${K}Arr` + backing array), return the element expressions `[e0, e1, …]` so a flatMap can splat
-      * them downstream with NO array allocation. The expanded shape (any leaf kind) is:
-      *   Block( ValDef("out", new Array[K](n)) :: out.update(0,e0) :: out.update(1,e1) :: … ,
-      *          new ${K}Arr(out, n) )
-      * wrapped in `Inlined`/`Typed`/`TypeApply(_, "$asInstanceOf$")`. Match it structurally (peel the wrappers,
-      * confirm the result is `new …Arr(<out>, _)`, then read the `<out>.update(i, e_i)` stores in index order). A
-      * non-literal body (variable `FArray`, a `range`/`tabulate`, an empty/1-elem special-case, …) returns None. */
+    /** If `body` is a LITERAL fixed-arity `FArray(e0, e1, …)` construction (which inline-expands to a Block that allocates a `${K}Arr` + backing array), return
+      * the element expressions `[e0, e1, …]` so a flatMap can splat them downstream with NO array allocation. The expanded shape (any leaf kind) is: Block(
+      * ValDef("out", new Array[K](n)) :: out.update(0,e0) :: out.update(1,e1) :: … , new ${K}Arr(out, n) ) wrapped in `Inlined`/`Typed`/`TypeApply(_,
+      * "$asInstanceOf$")`. Match it structurally (peel the wrappers, confirm the result is `new …Arr(<out>, _)`, then read the `<out>.update(i, e_i)` stores in
+      * index order). A non-literal body (variable `FArray`, a `range`/`tabulate`, an empty/1-elem special-case, …) returns None.
+      */
     def literalArrayElems(body: Term): Option[List[Term]] =
       // peel asInstanceOf / Typed / single-expr Inlined wrappers WITHOUT collapsing a stmt-bearing Block.
       def peel(t: Term): Term = t match
-        case TypeApply(Select(inner, "$asInstanceOf$"), _) => peel(inner)
-        case TypeApply(Select(inner, "asInstanceOf"), _)   => peel(inner)
-        case Typed(inner, _)                               => peel(inner)
-        case Inlined(_, Nil, inner)                         => peel(inner)
+        case TypeApply(Select(inner, "$asInstanceOf$"), _)                          => peel(inner)
+        case TypeApply(Select(inner, "asInstanceOf"), _)                            => peel(inner)
+        case Typed(inner, _)                                                        => peel(inner)
+        case Inlined(_, Nil, inner)                                                 => peel(inner)
         case Inlined(_, bindings, inner) if bindings.forall(_.isInstanceOf[ValDef]) => peel(inner)
-        case _                                             => t
+        case _                                                                      => t
       peel(body) match
         case Block(stmts, last) =>
           // the result must be `new ${K}Arr(outIdent, lenLit)`; capture the `out` symbol. Covers every leaf:

--- a/farray/src/scala/farray/FuseMacro.scala
+++ b/farray/src/scala/farray/FuseMacro.scala
@@ -101,7 +101,7 @@ object FuseMacro:
     final case class ZipS(that: Term, bTpe: TypeRepr, combine: Option[Term]) extends Stage // zip (None) / map2 (Some f)
 
     enum Kind:
-      case KInt, KLong, KDouble, KRef
+      case KInt, KLong, KDouble, KFloat, KShort, KByte, KChar, KBoolean, KRef
     // Specialize-or-fail, mirroring the eager API's `Repr` evidence (RefRepr requires A <: AnyRef): a primitive
     // kind needs the EXACT type; a reference kind needs `<: AnyRef`. Anything else (Any/AnyVal/Matchable, an
     // unbounded type param) can't be read unboxed — a primitive-backed FArray covariantly widened to such a
@@ -110,10 +110,15 @@ object FuseMacro:
       if t =:= TypeRepr.of[Int] then Kind.KInt
       else if t =:= TypeRepr.of[Long] then Kind.KLong
       else if t =:= TypeRepr.of[Double] then Kind.KDouble
+      else if t =:= TypeRepr.of[Float] then Kind.KFloat
+      else if t =:= TypeRepr.of[Short] then Kind.KShort
+      else if t =:= TypeRepr.of[Byte] then Kind.KByte
+      else if t =:= TypeRepr.of[Char] then Kind.KChar
+      else if t =:= TypeRepr.of[Boolean] then Kind.KBoolean
       else if t <:< TypeRepr.of[AnyRef] then Kind.KRef
       else
         report.errorAndAbort(
-          s"fuse: cannot specialize element type `${t.show}` — fused pipelines support Int, Long, Double, or a " +
+          s"fuse: cannot specialize element type `${t.show}` — fused pipelines support the JVM primitives or a " +
             s"reference type (`<: AnyRef`). A primitive-backed FArray widened to Any/AnyVal can't be read unboxed; " +
             s"use a concrete element type."
         )
@@ -283,10 +288,15 @@ object FuseMacro:
 
     /** read `src(idx)` unboxed at the given element kind (leaf fast-path lives inside `<kind>At`). */
     def readAtKind(elemTpe: TypeRepr, src: Expr[FBase], idx: Expr[Int]): Term = kindOf(elemTpe) match
-      case Kind.KInt    => '{ FArrayOps.intAt($src, $idx) }.asTerm
-      case Kind.KLong   => '{ FArrayOps.longAt($src, $idx) }.asTerm
-      case Kind.KDouble => '{ FArrayOps.doubleAt($src, $idx) }.asTerm
-      case Kind.KRef    => elemTpe.asType match { case '[b] => '{ FArrayOps.refAt($src, $idx).asInstanceOf[b] }.asTerm }
+      case Kind.KInt     => '{ FArrayOps.intAt($src, $idx) }.asTerm
+      case Kind.KLong    => '{ FArrayOps.longAt($src, $idx) }.asTerm
+      case Kind.KDouble  => '{ FArrayOps.doubleAt($src, $idx) }.asTerm
+      case Kind.KFloat   => '{ FArrayOps.floatAt($src, $idx) }.asTerm
+      case Kind.KShort   => '{ FArrayOps.shortAt($src, $idx) }.asTerm
+      case Kind.KByte    => '{ FArrayOps.byteAt($src, $idx) }.asTerm
+      case Kind.KChar    => '{ FArrayOps.charAt($src, $idx) }.asTerm
+      case Kind.KBoolean => '{ FArrayOps.booleanAt($src, $idx) }.asTerm
+      case Kind.KRef     => elemTpe.asType match { case '[b] => '{ FArrayOps.refAt($src, $idx).asInstanceOf[b] }.asTerm }
 
     /** the `(value, index)` pair for zipWithIndex; use the stdlib @specialized Tuple2 for a primitive element (Int/Long/Double) so it isn't boxed — exactly
       * like the eager zipWithIndex. Everything else boxes via a plain Tuple2 (correct for references and the rarer primitive kinds).
@@ -1056,6 +1066,56 @@ object FuseMacro:
                   case s =>
                     val len = s.length; var i = 0
                     while ${ cond('len, 'i) } do { ${ perElem('{ FArrayOps.doubleAt(s, i) }.asTerm) }; i += 1 }
+              }
+            case Kind.KFloat =>
+              '{
+                $src match
+                  case leaf: FloatArr =>
+                    val a = leaf.arr; val len = a.length; var i = 0
+                    while ${ cond('len, 'i) } do { ${ perElem('{ a(i) }.asTerm) }; i += 1 }
+                  case s =>
+                    val len = s.length; var i = 0
+                    while ${ cond('len, 'i) } do { ${ perElem('{ FArrayOps.floatAt(s, i) }.asTerm) }; i += 1 }
+              }
+            case Kind.KShort =>
+              '{
+                $src match
+                  case leaf: ShortArr =>
+                    val a = leaf.arr; val len = a.length; var i = 0
+                    while ${ cond('len, 'i) } do { ${ perElem('{ a(i) }.asTerm) }; i += 1 }
+                  case s =>
+                    val len = s.length; var i = 0
+                    while ${ cond('len, 'i) } do { ${ perElem('{ FArrayOps.shortAt(s, i) }.asTerm) }; i += 1 }
+              }
+            case Kind.KByte =>
+              '{
+                $src match
+                  case leaf: ByteArr =>
+                    val a = leaf.arr; val len = a.length; var i = 0
+                    while ${ cond('len, 'i) } do { ${ perElem('{ a(i) }.asTerm) }; i += 1 }
+                  case s =>
+                    val len = s.length; var i = 0
+                    while ${ cond('len, 'i) } do { ${ perElem('{ FArrayOps.byteAt(s, i) }.asTerm) }; i += 1 }
+              }
+            case Kind.KChar =>
+              '{
+                $src match
+                  case leaf: CharArr =>
+                    val a = leaf.arr; val len = a.length; var i = 0
+                    while ${ cond('len, 'i) } do { ${ perElem('{ a(i) }.asTerm) }; i += 1 }
+                  case s =>
+                    val len = s.length; var i = 0
+                    while ${ cond('len, 'i) } do { ${ perElem('{ FArrayOps.charAt(s, i) }.asTerm) }; i += 1 }
+              }
+            case Kind.KBoolean =>
+              '{
+                $src match
+                  case leaf: BooleanArr =>
+                    val a = leaf.arr; val len = a.length; var i = 0
+                    while ${ cond('len, 'i) } do { ${ perElem('{ a(i) }.asTerm) }; i += 1 }
+                  case s =>
+                    val len = s.length; var i = 0
+                    while ${ cond('len, 'i) } do { ${ perElem('{ FArrayOps.booleanAt(s, i) }.asTerm) }; i += 1 }
               }
             case Kind.KRef =>
               '{
@@ -1940,6 +2000,101 @@ object FuseMacro:
               else if o == 1 then new DoubleOne(out(0))
               else if o == cap then new DoubleArr(out, o)
               else new DoubleArr(java.util.Arrays.copyOf(out, o), o)
+            }.asTerm
+        case Kind.KFloat =>
+          if needsGrow then
+            '{
+              var out = new Array[Float](java.lang.Math.max(8, $n0)); var o = 0
+              ${ loop(v => '{ if o >= out.length then out = FArrayOps.ensureCapFloat(out, o + 1); out(o) = ${ v.asExprOf[Float] }; o += 1 }.asTerm) }
+              if o == 0 then (Empty.INSTANCE: FBase)
+              else if o == 1 then new FloatOne(out(0))
+              else if o == out.length then new FloatArr(out, o)
+              else new FloatArr(java.util.Arrays.copyOf(out, o), o)
+            }.asTerm
+          else
+            '{
+              val cap = ${ capExpr(n0, counters) }; val out = new Array[Float](cap); var o = 0
+              ${ loop(v => '{ out(o) = ${ v.asExprOf[Float] }; o += 1 }.asTerm) }
+              if o == 0 then (Empty.INSTANCE: FBase)
+              else if o == 1 then new FloatOne(out(0))
+              else if o == cap then new FloatArr(out, o)
+              else new FloatArr(java.util.Arrays.copyOf(out, o), o)
+            }.asTerm
+        case Kind.KShort =>
+          if needsGrow then
+            '{
+              var out = new Array[Short](java.lang.Math.max(8, $n0)); var o = 0
+              ${ loop(v => '{ if o >= out.length then out = FArrayOps.ensureCapShort(out, o + 1); out(o) = ${ v.asExprOf[Short] }; o += 1 }.asTerm) }
+              if o == 0 then (Empty.INSTANCE: FBase)
+              else if o == 1 then new ShortOne(out(0))
+              else if o == out.length then new ShortArr(out, o)
+              else new ShortArr(java.util.Arrays.copyOf(out, o), o)
+            }.asTerm
+          else
+            '{
+              val cap = ${ capExpr(n0, counters) }; val out = new Array[Short](cap); var o = 0
+              ${ loop(v => '{ out(o) = ${ v.asExprOf[Short] }; o += 1 }.asTerm) }
+              if o == 0 then (Empty.INSTANCE: FBase)
+              else if o == 1 then new ShortOne(out(0))
+              else if o == cap then new ShortArr(out, o)
+              else new ShortArr(java.util.Arrays.copyOf(out, o), o)
+            }.asTerm
+        case Kind.KByte =>
+          if needsGrow then
+            '{
+              var out = new Array[Byte](java.lang.Math.max(8, $n0)); var o = 0
+              ${ loop(v => '{ if o >= out.length then out = FArrayOps.ensureCapByte(out, o + 1); out(o) = ${ v.asExprOf[Byte] }; o += 1 }.asTerm) }
+              if o == 0 then (Empty.INSTANCE: FBase)
+              else if o == 1 then new ByteOne(out(0))
+              else if o == out.length then new ByteArr(out, o)
+              else new ByteArr(java.util.Arrays.copyOf(out, o), o)
+            }.asTerm
+          else
+            '{
+              val cap = ${ capExpr(n0, counters) }; val out = new Array[Byte](cap); var o = 0
+              ${ loop(v => '{ out(o) = ${ v.asExprOf[Byte] }; o += 1 }.asTerm) }
+              if o == 0 then (Empty.INSTANCE: FBase)
+              else if o == 1 then new ByteOne(out(0))
+              else if o == cap then new ByteArr(out, o)
+              else new ByteArr(java.util.Arrays.copyOf(out, o), o)
+            }.asTerm
+        case Kind.KChar =>
+          if needsGrow then
+            '{
+              var out = new Array[Char](java.lang.Math.max(8, $n0)); var o = 0
+              ${ loop(v => '{ if o >= out.length then out = FArrayOps.ensureCapChar(out, o + 1); out(o) = ${ v.asExprOf[Char] }; o += 1 }.asTerm) }
+              if o == 0 then (Empty.INSTANCE: FBase)
+              else if o == 1 then new CharOne(out(0))
+              else if o == out.length then new CharArr(out, o)
+              else new CharArr(java.util.Arrays.copyOf(out, o), o)
+            }.asTerm
+          else
+            '{
+              val cap = ${ capExpr(n0, counters) }; val out = new Array[Char](cap); var o = 0
+              ${ loop(v => '{ out(o) = ${ v.asExprOf[Char] }; o += 1 }.asTerm) }
+              if o == 0 then (Empty.INSTANCE: FBase)
+              else if o == 1 then new CharOne(out(0))
+              else if o == cap then new CharArr(out, o)
+              else new CharArr(java.util.Arrays.copyOf(out, o), o)
+            }.asTerm
+        case Kind.KBoolean =>
+          if needsGrow then
+            '{
+              var out = new Array[Boolean](java.lang.Math.max(8, $n0)); var o = 0
+              ${ loop(v => '{ if o >= out.length then out = FArrayOps.ensureCapBoolean(out, o + 1); out(o) = ${ v.asExprOf[Boolean] }; o += 1 }.asTerm) }
+              if o == 0 then (Empty.INSTANCE: FBase)
+              else if o == 1 then new BooleanOne(out(0))
+              else if o == out.length then new BooleanArr(out, o)
+              else new BooleanArr(java.util.Arrays.copyOf(out, o), o)
+            }.asTerm
+          else
+            '{
+              val cap = ${ capExpr(n0, counters) }; val out = new Array[Boolean](cap); var o = 0
+              ${ loop(v => '{ out(o) = ${ v.asExprOf[Boolean] }; o += 1 }.asTerm) }
+              if o == 0 then (Empty.INSTANCE: FBase)
+              else if o == 1 then new BooleanOne(out(0))
+              else if o == cap then new BooleanArr(out, o)
+              else new BooleanArr(java.util.Arrays.copyOf(out, o), o)
             }.asTerm
         case Kind.KRef =>
           if needsGrow then

--- a/farray/src/scala/farray/FuseMacro.scala
+++ b/farray/src/scala/farray/FuseMacro.scala
@@ -945,31 +945,60 @@ object FuseMacro:
         case None    => '{ $i < $len }
       def perElem(read: Term): Expr[Unit] =
         letBind(read)(x => buildBody(ss, x, ctx)).asExprOf[Unit]
-      // ONE indexed loop per kind via the `${kind}At` accessor — no `isInstanceOf[${K}Arr]` leaf fast-path.
-      // (The hybrid-traversal base makes `${kind}At` plenty fast on flat leaves; a separate agent owns that
-      // speed. The old fast-path also baked in a leaf-layout assumption that doesn't hold on every node.)
+      // A `${K}Arr` LEAF fast-path peeled INLINE ahead of the `${kind}At` fallback. Why it matters: a `flatMap`
+      // inner builds a fresh small `${K}Arr` PER ELEMENT; reading it back through `${kind}At` (an FBase-typed
+      // megamorphic call) makes the freshly-allocated array ESCAPE, so the JIT can't scalar-replace it — on
+      // HotSpot C2 (weaker escape analysis than GraalVM) this turns a no-alloc fused pass into a per-element
+      // allocation and craters it (measured ~13x slower than eager). Reading `leaf.arr(i)` from a CONCRETE
+      // `${K}Arr` is monomorphic and INLINE (no call boundary) so EA proves the array stays local → scalar-
+      // replaced, no alloc, on both JVMs. The `${kind}At` arm still serves genuine tree sources (Concat/Slice/…).
+      // NOTE (measured, do NOT "simplify" back): routing this through the SHARED `foreachLeaf${K}`/`scFwdLeaf${K}`
+      // driver (push each element through a `${K}Consumer`/`${K}Pred` SAM) is 1.7-2.8x SLOWER here — passing the
+      // fresh inner array INTO a shared method is itself an escape boundary that defeats scalar replacement on
+      // BOTH C2 and GraalVM. The inline leaf-match is the point. Loop bound is `a.length` (the backing array's),
+      // NOT leaf.length, so the JIT drops the per-element bounds check.
       elemTpe.asType match
         case '[se] =>
           k match
             case Kind.KInt =>
               '{
-                val s = $src; val len = s.length; var i = 0
-                while ${ cond('len, 'i) } do { ${ perElem('{ FArrayOps.intAt(s, i) }.asTerm) }; i += 1 }
+                $src match
+                  case leaf: IntArr =>
+                    val a = leaf.arr; val len = a.length; var i = 0
+                    while ${ cond('len, 'i) } do { ${ perElem('{ a(i) }.asTerm) }; i += 1 }
+                  case s =>
+                    val len = s.length; var i = 0
+                    while ${ cond('len, 'i) } do { ${ perElem('{ FArrayOps.intAt(s, i) }.asTerm) }; i += 1 }
               }
             case Kind.KLong =>
               '{
-                val s = $src; val len = s.length; var i = 0
-                while ${ cond('len, 'i) } do { ${ perElem('{ FArrayOps.longAt(s, i) }.asTerm) }; i += 1 }
+                $src match
+                  case leaf: LongArr =>
+                    val a = leaf.arr; val len = a.length; var i = 0
+                    while ${ cond('len, 'i) } do { ${ perElem('{ a(i) }.asTerm) }; i += 1 }
+                  case s =>
+                    val len = s.length; var i = 0
+                    while ${ cond('len, 'i) } do { ${ perElem('{ FArrayOps.longAt(s, i) }.asTerm) }; i += 1 }
               }
             case Kind.KDouble =>
               '{
-                val s = $src; val len = s.length; var i = 0
-                while ${ cond('len, 'i) } do { ${ perElem('{ FArrayOps.doubleAt(s, i) }.asTerm) }; i += 1 }
+                $src match
+                  case leaf: DoubleArr =>
+                    val a = leaf.arr; val len = a.length; var i = 0
+                    while ${ cond('len, 'i) } do { ${ perElem('{ a(i) }.asTerm) }; i += 1 }
+                  case s =>
+                    val len = s.length; var i = 0
+                    while ${ cond('len, 'i) } do { ${ perElem('{ FArrayOps.doubleAt(s, i) }.asTerm) }; i += 1 }
               }
             case Kind.KRef =>
               '{
-                val s = $src; val len = s.length; var i = 0
-                while ${ cond('len, 'i) } do { ${ perElem('{ FArrayOps.refAt(s, i).asInstanceOf[se] }.asTerm) }; i += 1 }
+                $src match
+                  case leaf: RefArr =>
+                    val a = leaf.arr; val len = a.length; var i = 0
+                    while ${ cond('len, 'i) } do { ${ perElem('{ a(i).asInstanceOf[se] }.asTerm) }; i += 1 }
+                  case s =>
+                    val len = s.length; var i = 0
+                    while ${ cond('len, 'i) } do { ${ perElem('{ FArrayOps.refAt(s, i).asInstanceOf[se] }.asTerm) }; i += 1 }
               }
 
     // ===== JSON source lowering: a per-record byte scanner whose record is a Tup of byte-sourced columns =====

--- a/farray/src/scala/farray/FuseMacro.scala
+++ b/farray/src/scala/farray/FuseMacro.scala
@@ -216,13 +216,14 @@ object FuseMacro:
         case _                                             => t
       peel(body) match
         case Block(stmts, last) =>
-          // the result must be `new ${K}Arr(outIdent, lenLit)`; capture the `out` symbol. PRIMITIVE leaves only
-          // (IntArr/LongArr/DoubleArr): their stored element exprs are clean `Typed(e, K)` we can re-splice
-          // straight downstream. The Ref leaf (RefArr) wraps each element in `(e: A).asInstanceOf[Object]`, which
-          // does not re-splice cleanly AND has no boxing win to recover (Ref was already a tie) — skip it.
-          val primArr = Set("IntArr", "LongArr", "DoubleArr")
+          // the result must be `new ${K}Arr(outIdent, lenLit)`; capture the `out` symbol. Covers every leaf:
+          //   - PRIMITIVE (IntArr/LongArr/DoubleArr): stores are `Typed(e, K)` — strip the ascription to `e`.
+          //   - REF (RefArr): stores are `(e: A).asInstanceOf[Object]` — strip the `.asInstanceOf[Object]` AND
+          //     the `Typed(_, A)` to recover the clean A-typed `e`. The downstream segment expects an A-typed
+          //     element, so the bare `e` (typed A by construction) re-splices correctly.
+          val leafArr = Set("IntArr", "LongArr", "DoubleArr", "RefArr")
           val outName: Option[String] = peel(last) match
-            case Apply(Select(New(tp), "<init>"), List(outRef, _)) if primArr.contains(tp.tpe.typeSymbol.name) =>
+            case Apply(Select(New(tp), "<init>"), List(outRef, _)) if leafArr.contains(tp.tpe.typeSymbol.name) =>
               outRef match { case Ident(nm) => Some(nm); case _ => None }
             case _ => None
           outName.flatMap { nm =>
@@ -235,10 +236,14 @@ object FuseMacro:
                   case Apply(Select(New(_), "<init>"), List(Literal(IntConstant(k))))               => k
                   case _                                                                            => -1
             }
-            // strip the `Typed(e, K)` ascription the prim store carries — `e` itself is the clean element expr.
-            def stripTyped(t: Term): Term = t match { case Typed(e, _) => stripTyped(e); case _ => t }
+            // strip the store wrapper to the clean element expr: a prim `Typed(e, K)` ascription, or a Ref
+            // `(e: A).asInstanceOf[Object]` cast (peel the cast, then the `Typed(_, A)`).
+            def stripStore(t: Term): Term = t match
+              case TypeApply(Select(inner, "asInstanceOf"), _) => stripStore(inner)
+              case Typed(e, _)                                 => stripStore(e)
+              case _                                           => t
             val updates: List[(Int, Term)] = stmts.collect {
-              case Apply(Select(Ident(n), "update"), List(Literal(IntConstant(idx)), elem)) if n == nm => (idx, stripTyped(elem))
+              case Apply(Select(Ident(n), "update"), List(Literal(IntConstant(idx)), elem)) if n == nm => (idx, stripStore(elem))
             }
             sizeOpt match
               case Some(k) if k >= 0 && updates.length == k && updates.map(_._1).sorted == (0 until k).toList =>

--- a/tests/snapshots/fused-pipeline.snap
+++ b/tests/snapshots/fused-pipeline.snap
@@ -22,20 +22,38 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      val `v₂`: Int = v.+(1)
-      val `v₃`: Int = `v₂`.%(2)
-      val `v₄`: Boolean = `v₃`.==(0)
-      if (`v₄`) {
-        val `v₅`: Int = `v₂`.*(2)
-        out.update(o, `v₅`)
-        o = o.+(1)
-      } else ()
-      i = i.+(1)
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len)) {
+          val v: Int = a.apply(i)
+          val `v₂`: Int = v.+(1)
+          val `v₃`: Int = `v₂`.%(2)
+          val `v₄`: Boolean = `v₃`.==(0)
+          if (`v₄`) {
+            val `v₅`: Int = `v₂`.*(2)
+            out.update(o, `v₅`)
+            o = o.+(1)
+          } else ()
+          i = i.+(1)
+        }
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`)) {
+          val `v₆`: Int = FArrayOps.intAt(s, `i₂`)
+          val `v₇`: Int = `v₆`.+(1)
+          val `v₈`: Int = `v₇`.%(2)
+          val `v₉`: Boolean = `v₈`.==(0)
+          if (`v₉`) {
+            val `v₁₀`: Int = `v₇`.*(2)
+            out.update(o, `v₁₀`)
+            o = o.+(1)
+          } else ()
+          `i₂` = `i₂`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -66,24 +84,46 @@
     val cap: Int = java.lang.Math.min(n0, lim)
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len).&&(done.unary_!)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      val `v₂`: Int = v.%(2)
-      val `v₃`: Boolean = `v₂`.==(0)
-      if (`v₃`) {
-        val cv: Int = c
-        if (cv.>=(lim)) done = true else {
-          val `v₄`: Int = v.*(10)
-          out.update(o, `v₄`)
-          o = o.+(1)
-          c = c.+(1)
-          if (cv.+(1).>=(lim)) done = true else ()
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len).&&(done.unary_!)) {
+          val v: Int = a.apply(i)
+          val `v₂`: Int = v.%(2)
+          val `v₃`: Boolean = `v₂`.==(0)
+          if (`v₃`) {
+            val cv: Int = c
+            if (cv.>=(lim)) done = true else {
+              val `v₄`: Int = v.*(10)
+              out.update(o, `v₄`)
+              o = o.+(1)
+              c = c.+(1)
+              if (cv.+(1).>=(lim)) done = true else ()
+            }
+          } else ()
+          i = i.+(1)
         }
-      } else ()
-      i = i.+(1)
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
+          val `v₅`: Int = FArrayOps.intAt(s, `i₂`)
+          val `v₆`: Int = `v₅`.%(2)
+          val `v₇`: Boolean = `v₆`.==(0)
+          if (`v₇`) {
+            val `cv₂`: Int = c
+            if (`cv₂`.>=(lim)) done = true else {
+              val `v₈`: Int = `v₅`.*(10)
+              out.update(o, `v₈`)
+              o = o.+(1)
+              c = c.+(1)
+              if (`cv₂`.+(1).>=(lim)) done = true else ()
+            }
+          } else ()
+          `i₂` = `i₂`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -120,21 +160,40 @@
     val cap: Int = java.lang.Math.min(n0, `lim₂`)
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len).&&(done.unary_!)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      if (c.<(lim)) c = c.+(1) else {
-        val cv: Int = `c₂`
-        if (cv.>=(`lim₂`)) done = true else {
-          out.update(o, v)
-          o = o.+(1)
-          `c₂` = `c₂`.+(1)
-          if (cv.+(1).>=(`lim₂`)) done = true else ()
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len).&&(done.unary_!)) {
+          val v: Int = a.apply(i)
+          if (c.<(lim)) c = c.+(1) else {
+            val cv: Int = `c₂`
+            if (cv.>=(`lim₂`)) done = true else {
+              out.update(o, v)
+              o = o.+(1)
+              `c₂` = `c₂`.+(1)
+              if (cv.+(1).>=(`lim₂`)) done = true else ()
+            }
+          }
+          i = i.+(1)
         }
-      }
-      i = i.+(1)
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
+          val `v₂`: Int = FArrayOps.intAt(s, `i₂`)
+          if (c.<(lim)) c = c.+(1) else {
+            val `cv₂`: Int = `c₂`
+            if (`cv₂`.>=(`lim₂`)) done = true else {
+              out.update(o, `v₂`)
+              o = o.+(1)
+              `c₂` = `c₂`.+(1)
+              if (`cv₂`.+(1).>=(`lim₂`)) done = true else ()
+            }
+          }
+          `i₂` = `i₂`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -161,14 +220,26 @@
       var acc: Int = 0
 
       ({
-        val s: FBase = src0
-        val len: Int = s.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = FArrayOps.intAt(s, i)
-          val `v₂`: Int = v.+(1)
-          acc = acc.+(`v₂`)
-          i = i.+(1)
+        src0 match {
+          case leaf: IntArr =>
+            val a: Array[Int] = leaf.arr
+            val len: Int = a.length
+            var i: Int = 0
+            while (i.<(len)) {
+              val v: Int = a.apply(i)
+              val `v₂`: Int = v.+(1)
+              acc = acc.+(`v₂`)
+              i = i.+(1)
+            }
+          case s =>
+            val `len₂`: Int = s.length
+            var `i₂`: Int = 0
+            while (`i₂`.<(`len₂`)) {
+              val `v₃`: Int = FArrayOps.intAt(s, `i₂`)
+              val `v₄`: Int = `v₃`.+(1)
+              acc = acc.+(`v₄`)
+              `i₂` = `i₂`.+(1)
+            }
         }
         acc
       }: Int)
@@ -194,15 +265,28 @@
     val cap: Int = n0
     val out: Array[Object] = new Array[Object](cap)
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      val `v₂`: Int = v.*(2)
-      out.update(o, new Tuple2$mcII$sp(v, `v₂`).asInstanceOf[Tuple2[Int, Int]].asInstanceOf[Object])
-      o = o.+(1)
-      i = i.+(1)
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len)) {
+          val v: Int = a.apply(i)
+          val `v₂`: Int = v.*(2)
+          out.update(o, new Tuple2$mcII$sp(v, `v₂`).asInstanceOf[Tuple2[Int, Int]].asInstanceOf[Object])
+          o = o.+(1)
+          i = i.+(1)
+        }
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`)) {
+          val `v₃`: Int = FArrayOps.intAt(s, `i₂`)
+          val `v₄`: Int = `v₃`.*(2)
+          out.update(o, new Tuple2$mcII$sp(`v₃`, `v₄`).asInstanceOf[Tuple2[Int, Int]].asInstanceOf[Object])
+          o = o.+(1)
+          `i₂` = `i₂`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new RefOne(out.apply(0)) else if (o.==(cap)) new RefArr(out, o) else new RefArr(java.util.Arrays.copyOf[Object](out, o), o)
   }.asInstanceOf[FArray[Tuple2[Int, Int]]]: FArray[Tuple2[Int, Int]])
@@ -229,18 +313,34 @@
       var c: Int = 0
 
       ({
-        val s: FBase = src0
-        val len: Int = s.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = FArrayOps.intAt(s, i)
-          val `v₂`: Int = v.%(2)
-          val `v₃`: Boolean = `v₂`.==(0)
-          if (`v₃`) {
-            c = c.+(1)
-            ()
-          } else ()
-          i = i.+(1)
+        src0 match {
+          case leaf: IntArr =>
+            val a: Array[Int] = leaf.arr
+            val len: Int = a.length
+            var i: Int = 0
+            while (i.<(len)) {
+              val v: Int = a.apply(i)
+              val `v₂`: Int = v.%(2)
+              val `v₃`: Boolean = `v₂`.==(0)
+              if (`v₃`) {
+                c = c.+(1)
+                ()
+              } else ()
+              i = i.+(1)
+            }
+          case s =>
+            val `len₂`: Int = s.length
+            var `i₂`: Int = 0
+            while (`i₂`.<(`len₂`)) {
+              val `v₄`: Int = FArrayOps.intAt(s, `i₂`)
+              val `v₅`: Int = `v₄`.%(2)
+              val `v₆`: Boolean = `v₅`.==(0)
+              if (`v₆`) {
+                c = c.+(1)
+                ()
+              } else ()
+              `i₂` = `i₂`.+(1)
+            }
         }
         c
       }: Int)
@@ -266,15 +366,28 @@
     val cap: Int = n0
     val out: Array[Object] = new Array[Object](cap)
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len)) {
-      val v: String = FArrayOps.refAt(s, i).asInstanceOf[String]
-      val `v₂`: String = v.toUpperCase()
-      out.update(o, `v₂`.asInstanceOf[Object])
-      o = o.+(1)
-      i = i.+(1)
+    src0 match {
+      case leaf: RefArr =>
+        val a: Array[Object] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len)) {
+          val v: String = a.apply(i).asInstanceOf[String]
+          val `v₂`: String = v.toUpperCase()
+          out.update(o, `v₂`.asInstanceOf[Object])
+          o = o.+(1)
+          i = i.+(1)
+        }
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`)) {
+          val `v₃`: String = FArrayOps.refAt(s, `i₂`).asInstanceOf[String]
+          val `v₄`: String = `v₃`.toUpperCase()
+          out.update(o, `v₄`.asInstanceOf[Object])
+          o = o.+(1)
+          `i₂` = `i₂`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new RefOne(out.apply(0)) else if (o.==(cap)) new RefArr(out, o) else new RefArr(java.util.Arrays.copyOf[Object](out, o), o)
   }.asInstanceOf[FArray[String]]: FArray[String])
@@ -298,18 +411,34 @@
     ({
       val src0: FBase = inline$base$i1[String](`Fuse_this₂`).asInstanceOf[FBase]
       val n0: Int = src0.length
-      val s: FBase = src0
-      val len: Int = s.length
-      var i: Int = 0
-      while (i.<(len)) {
-        val v: String = FArrayOps.refAt(s, i).asInstanceOf[String]
-        val `v₂`: StringOps = augmentString(v)
-        val `v₃`: Boolean = `v₂`.nonEmpty
-        if (`v₃`) {
-          System.out.println(v)
-          ()
-        } else ()
-        i = i.+(1)
+      src0 match {
+        case leaf: RefArr =>
+          val a: Array[Object] = leaf.arr
+          val len: Int = a.length
+          var i: Int = 0
+          while (i.<(len)) {
+            val v: String = a.apply(i).asInstanceOf[String]
+            val `v₂`: StringOps = augmentString(v)
+            val `v₃`: Boolean = `v₂`.nonEmpty
+            if (`v₃`) {
+              System.out.println(v)
+              ()
+            } else ()
+            i = i.+(1)
+          }
+        case s =>
+          val `len₂`: Int = s.length
+          var `i₂`: Int = 0
+          while (`i₂`.<(`len₂`)) {
+            val `v₄`: String = FArrayOps.refAt(s, `i₂`).asInstanceOf[String]
+            val `v₅`: StringOps = augmentString(`v₄`)
+            val `v₆`: Boolean = `v₅`.nonEmpty
+            if (`v₆`) {
+              System.out.println(`v₄`)
+              ()
+            } else ()
+            `i₂` = `i₂`.+(1)
+          }
       }
       ()
     }.asInstanceOf[Unit]: Unit)
@@ -349,41 +478,108 @@
     val n0: Int = src0.length
     var `out₂`: Array[Int] = new Array[Int](java.lang.Math.max(8, n0))
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      val `s₂`: FBase = {
-        val `$proxy₂`: FArray$package {
-          type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-        } = FArray$package.$asInstanceOf$[FArray$package {
-          type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-        }]
-        val `FArray$package$_this₂`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
-          type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-        }]
-        val `b$proxy₂`: Int = v.*(10)
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len)) {
+          val v: Int = a.apply(i)
+          {
+            val `$proxy₂`: FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            } = FArray$package.$asInstanceOf$[FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            }]
+            val `FArray$package$_this₂`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            }]
+            val `b$proxy₂`: Int = v.*(10)
 
-        (({
-          val `r₂`: intRepr.type = intRepr
-          val `out₃`: Array[Int] = new Array[Int](2)
-          `out₃`.update(0, (v: Int))
-          `out₃`.update(1, (v.*(10): Int))
-          new IntArr(`out₃`, 2)
-        }: FBase): FArray[Int])
-      }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase]
-      val `len₂`: Int = `s₂`.length
-      var `i₂`: Int = 0
-      while (`i₂`.<(`len₂`)) {
-        val `v₂`: Int = FArrayOps.intAt(`s₂`, `i₂`)
-        val `v₃`: Int = `v₂`.+(1)
-        if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-        `out₂`.update(o, `v₃`)
-        o = o.+(1)
-        `i₂` = `i₂`.+(1)
-      }
-      i = i.+(1)
+            (({
+              val `r₂`: intRepr.type = intRepr
+              val `out₃`: Array[Int] = new Array[Int](2)
+              `out₃`.update(0, (v: Int))
+              `out₃`.update(1, (v.*(10): Int))
+              new IntArr(`out₃`, 2)
+            }: FBase): FArray[Int])
+          }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
+            case leaf: IntArr =>
+              val `a₂`: Array[Int] = `leaf₂`.arr
+              val `len₂`: Int = `a₂`.length
+              var `i₂`: Int = 0
+              while (`i₂`.<(`len₂`)) {
+                val `v₂`: Int = `a₂`.apply(`i₂`)
+                val `v₃`: Int = `v₂`.+(1)
+                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                `out₂`.update(o, `v₃`)
+                o = o.+(1)
+                `i₂` = `i₂`.+(1)
+              }
+            case s =>
+              val `len₃`: Int = s.length
+              var `i₃`: Int = 0
+              while (`i₃`.<(`len₃`)) {
+                val `v₄`: Int = FArrayOps.intAt(s, `i₃`)
+                val `v₅`: Int = `v₄`.+(1)
+                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                `out₂`.update(o, `v₅`)
+                o = o.+(1)
+                `i₃` = `i₃`.+(1)
+              }
+          }
+          i = i.+(1)
+        }
+      case s =>
+        val `len₄`: Int = `s₂`.length
+        var `i₄`: Int = 0
+        while (`i₄`.<(`len₄`)) {
+          val `v₆`: Int = FArrayOps.intAt(`s₂`, `i₄`)
+          {
+            val `$proxy₃`: FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            } = FArray$package.$asInstanceOf$[FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            }]
+            val `FArray$package$_this₃`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            }]
+            val `b$proxy₃`: Int = `v₆`.*(10)
+
+            (({
+              val `r₃`: intRepr.type = intRepr
+              val `out₄`: Array[Int] = new Array[Int](2)
+              `out₄`.update(0, (`v₆`: Int))
+              `out₄`.update(1, (`v₆`.*(10): Int))
+              new IntArr(`out₄`, 2)
+            }: FBase): FArray[Int])
+          }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
+            case leaf: IntArr =>
+              val `a₃`: Array[Int] = `leaf₃`.arr
+              val `len₅`: Int = `a₃`.length
+              var `i₅`: Int = 0
+              while (`i₅`.<(`len₅`)) {
+                val `v₇`: Int = `a₃`.apply(`i₅`)
+                val `v₈`: Int = `v₇`.+(1)
+                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                `out₂`.update(o, `v₈`)
+                o = o.+(1)
+                `i₅` = `i₅`.+(1)
+              }
+            case s =>
+              val `len₆`: Int = `s₃`.length
+              var `i₆`: Int = 0
+              while (`i₆`.<(`len₆`)) {
+                val `v₉`: Int = FArrayOps.intAt(`s₃`, `i₆`)
+                val `v₁₀`: Int = `v₉`.+(1)
+                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                `out₂`.update(o, `v₁₀`)
+                o = o.+(1)
+                `i₆` = `i₆`.+(1)
+              }
+          }
+          `i₄` = `i₄`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(`out₂`.apply(0)) else if (o.==(`out₂`.length)) new IntArr(`out₂`, o) else new IntArr(java.util.Arrays.copyOf(`out₂`, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -406,17 +602,32 @@
     val n0: Int = src0.length
     var done: Boolean = false
     var res: Option[Any] = None
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len).&&(done.unary_!)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      val `v₂`: Int = v.+(1)
-      if (`v₂`.%(3).==(0)) {
-        res = Some.apply[Any](`v₂`)
-        done = true
-      } else ()
-      i = i.+(1)
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len).&&(done.unary_!)) {
+          val v: Int = a.apply(i)
+          val `v₂`: Int = v.+(1)
+          if (`v₂`.%(3).==(0)) {
+            res = Some.apply[Any](`v₂`)
+            done = true
+          } else ()
+          i = i.+(1)
+        }
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
+          val `v₃`: Int = FArrayOps.intAt(s, `i₂`)
+          val `v₄`: Int = `v₃`.+(1)
+          if (`v₄`.%(3).==(0)) {
+            res = Some.apply[Any](`v₄`)
+            done = true
+          } else ()
+          `i₂` = `i₂`.+(1)
+        }
     }
 
     (res: Option[Any])
@@ -442,20 +653,38 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      val `v₂`: Int = c
-      c = c.+(1)
-      val `v₃`: Int = `v₂`.%(2)
-      val `v₄`: Boolean = `v₃`.==(0)
-      if (`v₄`) {
-        out.update(o, v)
-        o = o.+(1)
-      } else ()
-      i = i.+(1)
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len)) {
+          val v: Int = a.apply(i)
+          val `v₂`: Int = c
+          c = c.+(1)
+          val `v₃`: Int = `v₂`.%(2)
+          val `v₄`: Boolean = `v₃`.==(0)
+          if (`v₄`) {
+            out.update(o, v)
+            o = o.+(1)
+          } else ()
+          i = i.+(1)
+        }
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`)) {
+          val `v₅`: Int = FArrayOps.intAt(s, `i₂`)
+          val `v₆`: Int = c
+          c = c.+(1)
+          val `v₇`: Int = `v₆`.%(2)
+          val `v₈`: Boolean = `v₇`.==(0)
+          if (`v₈`) {
+            out.update(o, `v₅`)
+            o = o.+(1)
+          } else ()
+          `i₂` = `i₂`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -523,20 +752,38 @@
     val cap: Int = java.lang.Math.min(n0, zn)
     val `out₃`: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len).&&(done.unary_!)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      if (c.>=(zn)) done = true else {
-        val pos: Int = c
-        c = c.+(1)
-        val `v₂`: Int = FArrayOps.intAt(zthat, pos)
-        val `v₃`: Int = v.+(`v₂`)
-        `out₃`.update(o, `v₃`)
-        o = o.+(1)
-      }
-      i = i.+(1)
+    src0 match {
+      case leaf: IntArr =>
+        val `a₂`: Array[Int] = leaf.arr
+        val len: Int = `a₂`.length
+        var i: Int = 0
+        while (i.<(len).&&(done.unary_!)) {
+          val v: Int = `a₂`.apply(i)
+          if (c.>=(zn)) done = true else {
+            val pos: Int = c
+            c = c.+(1)
+            val `v₂`: Int = FArrayOps.intAt(zthat, pos)
+            val `v₃`: Int = v.+(`v₂`)
+            `out₃`.update(o, `v₃`)
+            o = o.+(1)
+          }
+          i = i.+(1)
+        }
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
+          val `v₄`: Int = FArrayOps.intAt(s, `i₂`)
+          if (c.>=(zn)) done = true else {
+            val `pos₂`: Int = c
+            c = c.+(1)
+            val `v₅`: Int = FArrayOps.intAt(zthat, `pos₂`)
+            val `v₆`: Int = `v₄`.+(`v₅`)
+            `out₃`.update(o, `v₆`)
+            o = o.+(1)
+          }
+          `i₂` = `i₂`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(`out₃`.apply(0)) else if (o.==(cap)) new IntArr(`out₃`, o) else new IntArr(java.util.Arrays.copyOf(`out₃`, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -560,18 +807,34 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      val `v₂`: Int = v.*(v)
-      val `v₃`: Int = `v₂`.+(1)
-      val `v₄`: Int = `v₂`.+(2)
-      val `v₅`: Int = `v₃`.+(`v₄`)
-      out.update(o, `v₅`)
-      o = o.+(1)
-      i = i.+(1)
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len)) {
+          val v: Int = a.apply(i)
+          val `v₂`: Int = v.*(v)
+          val `v₃`: Int = `v₂`.+(1)
+          val `v₄`: Int = `v₂`.+(2)
+          val `v₅`: Int = `v₃`.+(`v₄`)
+          out.update(o, `v₅`)
+          o = o.+(1)
+          i = i.+(1)
+        }
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`)) {
+          val `v₆`: Int = FArrayOps.intAt(s, `i₂`)
+          val `v₇`: Int = `v₆`.*(`v₆`)
+          val `v₈`: Int = `v₇`.+(1)
+          val `v₉`: Int = `v₇`.+(2)
+          val `v₁₀`: Int = `v₈`.+(`v₉`)
+          out.update(o, `v₁₀`)
+          o = o.+(1)
+          `i₂` = `i₂`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -595,20 +858,38 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      val `v₂`: Int = v.+(1)
-      val `v₃`: Int = `v₂`.%(2)
-      val `v₄`: Boolean = `v₃`.==(0)
-      if (`v₄`) {
-        val `v₅`: Int = v.*(1000)
-        out.update(o, `v₅`)
-        o = o.+(1)
-      } else ()
-      i = i.+(1)
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len)) {
+          val v: Int = a.apply(i)
+          val `v₂`: Int = v.+(1)
+          val `v₃`: Int = `v₂`.%(2)
+          val `v₄`: Boolean = `v₃`.==(0)
+          if (`v₄`) {
+            val `v₅`: Int = v.*(1000)
+            out.update(o, `v₅`)
+            o = o.+(1)
+          } else ()
+          i = i.+(1)
+        }
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`)) {
+          val `v₆`: Int = FArrayOps.intAt(s, `i₂`)
+          val `v₇`: Int = `v₆`.+(1)
+          val `v₈`: Int = `v₇`.%(2)
+          val `v₉`: Boolean = `v₈`.==(0)
+          if (`v₉`) {
+            val `v₁₀`: Int = `v₆`.*(1000)
+            out.update(o, `v₁₀`)
+            o = o.+(1)
+          } else ()
+          `i₂` = `i₂`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -635,22 +916,42 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      v match {
-        case x if `x₂`.%(2).==(0) =>
-          {
-            val `v₂`: Int = `x₂`.*(10)
-            out.update(o, `v₂`)
-            o = o.+(1)
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len)) {
+          val v: Int = a.apply(i)
+          v match {
+            case x if `x₂`.%(2).==(0) =>
+              {
+                val `v₂`: Int = `x₂`.*(10)
+                out.update(o, `v₂`)
+                o = o.+(1)
+              }
+            case _ =>
+              ()
           }
-        case _ =>
-          ()
-      }
-      i = i.+(1)
+          i = i.+(1)
+        }
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`)) {
+          val `v₃`: Int = FArrayOps.intAt(s, `i₂`)
+          `v₃` match {
+            case x if `x₃`.%(2).==(0) =>
+              {
+                val `v₄`: Int = `x₃`.*(10)
+                out.update(o, `v₄`)
+                o = o.+(1)
+              }
+            case _ =>
+              ()
+          }
+          `i₂` = `i₂`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -675,16 +976,30 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len).&&(done.unary_!)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      if (v.<(5)) {
-        out.update(o, v)
-        o = o.+(1)
-      } else done = true
-      i = i.+(1)
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len).&&(done.unary_!)) {
+          val v: Int = a.apply(i)
+          if (v.<(5)) {
+            out.update(o, v)
+            o = o.+(1)
+          } else done = true
+          i = i.+(1)
+        }
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
+          val `v₂`: Int = FArrayOps.intAt(s, `i₂`)
+          if (`v₂`.<(5)) {
+            out.update(o, `v₂`)
+            o = o.+(1)
+          } else done = true
+          `i₂` = `i₂`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -711,20 +1026,38 @@
     if (o.>=(out.length)) out = FArrayOps.ensureCapInt(out, o.+(1)) else ()
     out.update(o, acc0)
     o = o.+(1)
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      acc0 = {
-        val `_$₂`: Int = acc0
-        `_$₂`.+(v)
-      }
-      val `v₂`: Int = acc0
-      if (o.>=(out.length)) out = FArrayOps.ensureCapInt(out, o.+(1)) else ()
-      out.update(o, `v₂`)
-      o = o.+(1)
-      i = i.+(1)
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len)) {
+          val v: Int = a.apply(i)
+          acc0 = {
+            val `_$₂`: Int = acc0
+            `_$₂`.+(v)
+          }
+          val `v₂`: Int = acc0
+          if (o.>=(out.length)) out = FArrayOps.ensureCapInt(out, o.+(1)) else ()
+          out.update(o, `v₂`)
+          o = o.+(1)
+          i = i.+(1)
+        }
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`)) {
+          val `v₃`: Int = FArrayOps.intAt(s, `i₂`)
+          acc0 = {
+            val `_$₃`: Int = acc0
+            `_$₃`.+(`v₃`)
+          }
+          val `v₄`: Int = acc0
+          if (o.>=(out.length)) out = FArrayOps.ensureCapInt(out, o.+(1)) else ()
+          out.update(o, `v₄`)
+          o = o.+(1)
+          `i₂` = `i₂`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(out.length)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -748,18 +1081,34 @@
     var done: Boolean = false
     var idx: Int = -1
     var c: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len).&&(done.unary_!)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      val `v₂`: Int = v.*(v)
-      if (`v₂`.>(9)) {
-        idx = c
-        done = true
-      } else ()
-      c = c.+(1)
-      i = i.+(1)
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len).&&(done.unary_!)) {
+          val v: Int = a.apply(i)
+          val `v₂`: Int = v.*(v)
+          if (`v₂`.>(9)) {
+            idx = c
+            done = true
+          } else ()
+          c = c.+(1)
+          i = i.+(1)
+        }
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
+          val `v₃`: Int = FArrayOps.intAt(s, `i₂`)
+          val `v₄`: Int = `v₃`.*(`v₃`)
+          if (`v₄`.>(9)) {
+            idx = c
+            done = true
+          } else ()
+          c = c.+(1)
+          `i₂` = `i₂`.+(1)
+        }
     }
 
     (idx: Int)
@@ -789,25 +1138,48 @@
         val n0: Int = src0.length
         var seeded: Boolean = false
         var acc: Int = null.asInstanceOf[Int]
-        val s: FBase = src0
-        val len: Int = s.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = FArrayOps.intAt(s, i)
-          val `v₂`: Int = v.%(2)
-          val `v₃`: Boolean = `v₂`.==(0)
-          if (`v₃`) {
-            if (seeded.unary_!) {
-              acc = v
-              seeded = true
-            } else acc = {
-              val `acc₂`: Int = acc
+        src0 match {
+          case leaf: IntArr =>
+            val a: Array[Int] = leaf.arr
+            val len: Int = a.length
+            var i: Int = 0
+            while (i.<(len)) {
+              val v: Int = a.apply(i)
+              val `v₂`: Int = v.%(2)
+              val `v₃`: Boolean = `v₂`.==(0)
+              if (`v₃`) {
+                if (seeded.unary_!) {
+                  acc = v
+                  seeded = true
+                } else acc = {
+                  val `acc₂`: Int = acc
 
-              (if (Int.lteq(`acc₂`, v)) `acc₂` else v: Int)
+                  (if (Int.lteq(`acc₂`, v)) `acc₂` else v: Int)
+                }
+                ()
+              } else ()
+              i = i.+(1)
             }
-            ()
-          } else ()
-          i = i.+(1)
+          case s =>
+            val `len₂`: Int = s.length
+            var `i₂`: Int = 0
+            while (`i₂`.<(`len₂`)) {
+              val `v₄`: Int = FArrayOps.intAt(s, `i₂`)
+              val `v₅`: Int = `v₄`.%(2)
+              val `v₆`: Boolean = `v₅`.==(0)
+              if (`v₆`) {
+                if (seeded.unary_!) {
+                  acc = `v₄`
+                  seeded = true
+                } else acc = {
+                  val `acc₃`: Int = acc
+
+                  (if (Int.lteq(`acc₃`, `v₄`)) `acc₃` else `v₄`: Int)
+                }
+                ()
+              } else ()
+              `i₂` = `i₂`.+(1)
+            }
         }
         if (seeded) Some.apply[Int](acc) else None
       }.asInstanceOf[Option[Int]]: Option[Int])
@@ -839,21 +1211,40 @@
         var seeded: Boolean = false
         var best: Any = null
         var bestK: Int = null.asInstanceOf[Int]
-        val s: FBase = src0
-        val len: Int = s.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = FArrayOps.intAt(s, i)
-          val kk: Int = v.unary_-
-          if (seeded.unary_!.||({
-            val k2: Int = bestK
-            Int.lt(kk, k2)
-          })) {
-            best = v
-            bestK = kk
-            seeded = true
-          } else ()
-          i = i.+(1)
+        src0 match {
+          case leaf: IntArr =>
+            val a: Array[Int] = leaf.arr
+            val len: Int = a.length
+            var i: Int = 0
+            while (i.<(len)) {
+              val v: Int = a.apply(i)
+              val kk: Int = v.unary_-
+              if (seeded.unary_!.||({
+                val k2: Int = bestK
+                Int.lt(kk, k2)
+              })) {
+                best = v
+                bestK = kk
+                seeded = true
+              } else ()
+              i = i.+(1)
+            }
+          case s =>
+            val `len₂`: Int = s.length
+            var `i₂`: Int = 0
+            while (`i₂`.<(`len₂`)) {
+              val `v₂`: Int = FArrayOps.intAt(s, `i₂`)
+              val `kk₂`: Int = `v₂`.unary_-
+              if (seeded.unary_!.||({
+                val `k2₂`: Int = bestK
+                Int.lt(`kk₂`, `k2₂`)
+              })) {
+                best = `v₂`
+                bestK = `kk₂`
+                seeded = true
+              } else ()
+              `i₂` = `i₂`.+(1)
+            }
         }
         if (seeded) Some.apply[Any](best) else None
       }.asInstanceOf[Option[Int]]: Option[Int])
@@ -879,16 +1270,30 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var `o₂`: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      val `v₂`: Int = v.*(3)
-      val `v₃`: Int = v.+(`v₂`)
-      out.update(`o₂`, `v₃`)
-      `o₂` = `o₂`.+(1)
-      i = i.+(1)
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len)) {
+          val v: Int = a.apply(i)
+          val `v₂`: Int = v.*(3)
+          val `v₃`: Int = v.+(`v₂`)
+          out.update(`o₂`, `v₃`)
+          `o₂` = `o₂`.+(1)
+          i = i.+(1)
+        }
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`)) {
+          val `v₄`: Int = FArrayOps.intAt(s, `i₂`)
+          val `v₅`: Int = `v₄`.*(3)
+          val `v₆`: Int = `v₄`.+(`v₅`)
+          out.update(`o₂`, `v₆`)
+          `o₂` = `o₂`.+(1)
+          `i₂` = `i₂`.+(1)
+        }
     }
     if (`o₂`.==(0)) (Empty.INSTANCE: FBase) else if (`o₂`.==(1)) new IntOne(out.apply(0)) else if (`o₂`.==(cap)) new IntArr(out, `o₂`) else new IntArr(java.util.Arrays.copyOf(out, `o₂`), `o₂`)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -919,19 +1324,36 @@
         var acc: Int = z$proxy
 
         ({
-          val s: FBase = src0
-          val len: Int = s.length
-          var i: Int = 0
-          while (i.<(len)) {
-            val v: Int = FArrayOps.intAt(s, i)
-            val `v₂`: Int = v.%(2)
-            val `v₃`: Boolean = `v₂`.==(0)
-            if (`v₃`) {
-              val `v₄`: Int = v.*(10)
-              acc = IntIsIntegral.plus(acc, `v₄`)
-              ()
-            } else ()
-            i = i.+(1)
+          src0 match {
+            case leaf: IntArr =>
+              val a: Array[Int] = leaf.arr
+              val len: Int = a.length
+              var i: Int = 0
+              while (i.<(len)) {
+                val v: Int = a.apply(i)
+                val `v₂`: Int = v.%(2)
+                val `v₃`: Boolean = `v₂`.==(0)
+                if (`v₃`) {
+                  val `v₄`: Int = v.*(10)
+                  acc = IntIsIntegral.plus(acc, `v₄`)
+                  ()
+                } else ()
+                i = i.+(1)
+              }
+            case s =>
+              val `len₂`: Int = s.length
+              var `i₂`: Int = 0
+              while (`i₂`.<(`len₂`)) {
+                val `v₅`: Int = FArrayOps.intAt(s, `i₂`)
+                val `v₆`: Int = `v₅`.%(2)
+                val `v₇`: Boolean = `v₆`.==(0)
+                if (`v₇`) {
+                  val `v₈`: Int = `v₅`.*(10)
+                  acc = IntIsIntegral.plus(acc, `v₈`)
+                  ()
+                } else ()
+                `i₂` = `i₂`.+(1)
+              }
           }
           acc
         }: Int)
@@ -958,15 +1380,28 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      val `v₂`: Int = v.+(1)
-      out.update(o, `v₂`)
-      o = o.+(1)
-      i = i.+(1)
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len)) {
+          val v: Int = a.apply(i)
+          val `v₂`: Int = v.+(1)
+          out.update(o, `v₂`)
+          o = o.+(1)
+          i = i.+(1)
+        }
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`)) {
+          val `v₃`: Int = FArrayOps.intAt(s, `i₂`)
+          val `v₄`: Int = `v₃`.+(1)
+          out.update(o, `v₄`)
+          o = o.+(1)
+          `i₂` = `i₂`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -1032,18 +1467,34 @@
     val cap: Int = java.lang.Math.min(n0, zn)
     val `out₃`: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len).&&(done.unary_!)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      if (c.>=(zn)) done = true else {
-        val pos: Int = c
-        c = c.+(1)
-        `out₃`.update(o, v)
-        o = o.+(1)
-      }
-      i = i.+(1)
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len).&&(done.unary_!)) {
+          val v: Int = a.apply(i)
+          if (c.>=(zn)) done = true else {
+            val pos: Int = c
+            c = c.+(1)
+            `out₃`.update(o, v)
+            o = o.+(1)
+          }
+          i = i.+(1)
+        }
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
+          val `v₂`: Int = FArrayOps.intAt(s, `i₂`)
+          if (c.>=(zn)) done = true else {
+            val `pos₂`: Int = c
+            c = c.+(1)
+            `out₃`.update(o, `v₂`)
+            o = o.+(1)
+          }
+          `i₂` = `i₂`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(`out₃`.apply(0)) else if (o.==(cap)) new IntArr(`out₃`, o) else new IntArr(java.util.Arrays.copyOf(`out₃`, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -1113,22 +1564,42 @@
     val cap: Int = java.lang.Math.min(n0, zn)
     val `out₃`: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len).&&(done.unary_!)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      if (c.>=(zn)) done = true else {
-        val pos: Int = c
-        c = c.+(1)
-        val `v₂`: Int = v.%(4)
-        val `v₃`: Boolean = `v₂`.==(0)
-        if (`v₃`) {
-          `out₃`.update(o, v)
-          o = o.+(1)
-        } else ()
-      }
-      i = i.+(1)
+    src0 match {
+      case leaf: IntArr =>
+        val `a₂`: Array[Int] = leaf.arr
+        val len: Int = `a₂`.length
+        var i: Int = 0
+        while (i.<(len).&&(done.unary_!)) {
+          val v: Int = `a₂`.apply(i)
+          if (c.>=(zn)) done = true else {
+            val pos: Int = c
+            c = c.+(1)
+            val `v₂`: Int = v.%(4)
+            val `v₃`: Boolean = `v₂`.==(0)
+            if (`v₃`) {
+              `out₃`.update(o, v)
+              o = o.+(1)
+            } else ()
+          }
+          i = i.+(1)
+        }
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
+          val `v₄`: Int = FArrayOps.intAt(s, `i₂`)
+          if (c.>=(zn)) done = true else {
+            val `pos₂`: Int = c
+            c = c.+(1)
+            val `v₅`: Int = `v₄`.%(4)
+            val `v₆`: Boolean = `v₅`.==(0)
+            if (`v₆`) {
+              `out₃`.update(o, `v₄`)
+              o = o.+(1)
+            } else ()
+          }
+          `i₂` = `i₂`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(`out₃`.apply(0)) else if (o.==(cap)) new IntArr(`out₃`, o) else new IntArr(java.util.Arrays.copyOf(`out₃`, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -1155,21 +1626,40 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      v match {
-        case x if `x₂`.>(2) =>
-          {
-            out.update(o, `x₂`)
-            o = o.+(1)
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len)) {
+          val v: Int = a.apply(i)
+          v match {
+            case x if `x₂`.>(2) =>
+              {
+                out.update(o, `x₂`)
+                o = o.+(1)
+              }
+            case _ =>
+              ()
           }
-        case _ =>
-          ()
-      }
-      i = i.+(1)
+          i = i.+(1)
+        }
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`)) {
+          val `v₂`: Int = FArrayOps.intAt(s, `i₂`)
+          `v₂` match {
+            case x if `x₃`.>(2) =>
+              {
+                out.update(o, `x₃`)
+                o = o.+(1)
+              }
+            case _ =>
+              ()
+          }
+          `i₂` = `i₂`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -1193,19 +1683,36 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      val `v₂`: Int = v.+(1)
-      val `v₃`: Boolean = `v₂`.>(2)
-      if (`v₃`) {
-        val `v₄`: Int = `v₂`.*(`v₂`)
-        out.update(o, `v₄`)
-        o = o.+(1)
-      } else ()
-      i = i.+(1)
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len)) {
+          val v: Int = a.apply(i)
+          val `v₂`: Int = v.+(1)
+          val `v₃`: Boolean = `v₂`.>(2)
+          if (`v₃`) {
+            val `v₄`: Int = `v₂`.*(`v₂`)
+            out.update(o, `v₄`)
+            o = o.+(1)
+          } else ()
+          i = i.+(1)
+        }
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`)) {
+          val `v₅`: Int = FArrayOps.intAt(s, `i₂`)
+          val `v₆`: Int = `v₅`.+(1)
+          val `v₇`: Boolean = `v₆`.>(2)
+          if (`v₇`) {
+            val `v₈`: Int = `v₆`.*(`v₆`)
+            out.update(o, `v₈`)
+            o = o.+(1)
+          } else ()
+          `i₂` = `i₂`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -1244,41 +1751,108 @@
     val n0: Int = src0.length
     var `out₂`: Array[Int] = new Array[Int](java.lang.Math.max(8, n0))
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      val `s₂`: FBase = {
-        val `$proxy₂`: FArray$package {
-          type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-        } = FArray$package.$asInstanceOf$[FArray$package {
-          type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-        }]
-        val `FArray$package$_this₂`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
-          type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-        }]
-        val `b$proxy₂`: Int = v.*(10)
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len)) {
+          val v: Int = a.apply(i)
+          {
+            val `$proxy₂`: FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            } = FArray$package.$asInstanceOf$[FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            }]
+            val `FArray$package$_this₂`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            }]
+            val `b$proxy₂`: Int = v.*(10)
 
-        (({
-          val `r₂`: intRepr.type = intRepr
-          val `out₃`: Array[Int] = new Array[Int](2)
-          `out₃`.update(0, (v: Int))
-          `out₃`.update(1, (v.*(10): Int))
-          new IntArr(`out₃`, 2)
-        }: FBase): FArray[Int])
-      }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase]
-      val `len₂`: Int = `s₂`.length
-      var `i₂`: Int = 0
-      while (`i₂`.<(`len₂`)) {
-        val `v₂`: Int = FArrayOps.intAt(`s₂`, `i₂`)
-        val `v₃`: Int = `v₂`.+(1)
-        if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-        `out₂`.update(o, `v₃`)
-        o = o.+(1)
-        `i₂` = `i₂`.+(1)
-      }
-      i = i.+(1)
+            (({
+              val `r₂`: intRepr.type = intRepr
+              val `out₃`: Array[Int] = new Array[Int](2)
+              `out₃`.update(0, (v: Int))
+              `out₃`.update(1, (v.*(10): Int))
+              new IntArr(`out₃`, 2)
+            }: FBase): FArray[Int])
+          }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
+            case leaf: IntArr =>
+              val `a₂`: Array[Int] = `leaf₂`.arr
+              val `len₂`: Int = `a₂`.length
+              var `i₂`: Int = 0
+              while (`i₂`.<(`len₂`)) {
+                val `v₂`: Int = `a₂`.apply(`i₂`)
+                val `v₃`: Int = `v₂`.+(1)
+                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                `out₂`.update(o, `v₃`)
+                o = o.+(1)
+                `i₂` = `i₂`.+(1)
+              }
+            case s =>
+              val `len₃`: Int = s.length
+              var `i₃`: Int = 0
+              while (`i₃`.<(`len₃`)) {
+                val `v₄`: Int = FArrayOps.intAt(s, `i₃`)
+                val `v₅`: Int = `v₄`.+(1)
+                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                `out₂`.update(o, `v₅`)
+                o = o.+(1)
+                `i₃` = `i₃`.+(1)
+              }
+          }
+          i = i.+(1)
+        }
+      case s =>
+        val `len₄`: Int = `s₂`.length
+        var `i₄`: Int = 0
+        while (`i₄`.<(`len₄`)) {
+          val `v₆`: Int = FArrayOps.intAt(`s₂`, `i₄`)
+          {
+            val `$proxy₃`: FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            } = FArray$package.$asInstanceOf$[FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            }]
+            val `FArray$package$_this₃`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            }]
+            val `b$proxy₃`: Int = `v₆`.*(10)
+
+            (({
+              val `r₃`: intRepr.type = intRepr
+              val `out₄`: Array[Int] = new Array[Int](2)
+              `out₄`.update(0, (`v₆`: Int))
+              `out₄`.update(1, (`v₆`.*(10): Int))
+              new IntArr(`out₄`, 2)
+            }: FBase): FArray[Int])
+          }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
+            case leaf: IntArr =>
+              val `a₃`: Array[Int] = `leaf₃`.arr
+              val `len₅`: Int = `a₃`.length
+              var `i₅`: Int = 0
+              while (`i₅`.<(`len₅`)) {
+                val `v₇`: Int = `a₃`.apply(`i₅`)
+                val `v₈`: Int = `v₇`.+(1)
+                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                `out₂`.update(o, `v₈`)
+                o = o.+(1)
+                `i₅` = `i₅`.+(1)
+              }
+            case s =>
+              val `len₆`: Int = `s₃`.length
+              var `i₆`: Int = 0
+              while (`i₆`.<(`len₆`)) {
+                val `v₉`: Int = FArrayOps.intAt(`s₃`, `i₆`)
+                val `v₁₀`: Int = `v₉`.+(1)
+                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                `out₂`.update(o, `v₁₀`)
+                o = o.+(1)
+                `i₆` = `i₆`.+(1)
+              }
+          }
+          `i₄` = `i₄`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(`out₂`.apply(0)) else if (o.==(`out₂`.length)) new IntArr(`out₂`, o) else new IntArr(java.util.Arrays.copyOf(`out₂`, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -1330,62 +1904,244 @@
     val n0: Int = src0.length
     var `out₂`: Array[Int] = new Array[Int](java.lang.Math.max(8, n0))
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      val `s₂`: FBase = {
-        val `$proxy₂`: FArray$package {
-          type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-        } = FArray$package.$asInstanceOf$[FArray$package {
-          type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-        }]
-        val `FArray$package$_this₃`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
-          type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-        }]
-        val `b$proxy₂`: Int = v.+(1)
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len)) {
+          val v: Int = a.apply(i)
+          {
+            val `$proxy₂`: FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            } = FArray$package.$asInstanceOf$[FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            }]
+            val `FArray$package$_this₃`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            }]
+            val `b$proxy₂`: Int = v.+(1)
 
-        (({
-          val `r₃`: intRepr.type = intRepr
-          val `out₃`: Array[Int] = new Array[Int](2)
-          `out₃`.update(0, (v: Int))
-          `out₃`.update(1, (v.+(1): Int))
-          new IntArr(`out₃`, 2)
-        }: FBase): FArray[Int])
-      }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase]
-      val `len₂`: Int = `s₂`.length
-      var `i₂`: Int = 0
-      while (`i₂`.<(`len₂`)) {
-        val `v₂`: Int = FArrayOps.intAt(`s₂`, `i₂`)
-        val `s₃`: FBase = {
-          val `$proxy₂`: FArray$package {
-            type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-          } = FArray$package.$asInstanceOf$[FArray$package {
-            type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-          }]
-          val `FArray$package$_this₄`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
-            type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-          }]
-          val `a$proxy₂`: Int = `v₂`.*(100)
+            (({
+              val `r₃`: intRepr.type = intRepr
+              val `out₃`: Array[Int] = new Array[Int](2)
+              `out₃`.update(0, (v: Int))
+              `out₃`.update(1, (v.+(1): Int))
+              new IntArr(`out₃`, 2)
+            }: FBase): FArray[Int])
+          }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
+            case leaf: IntArr =>
+              val `a₂`: Array[Int] = `leaf₂`.arr
+              val `len₂`: Int = `a₂`.length
+              var `i₂`: Int = 0
+              while (`i₂`.<(`len₂`)) {
+                val `v₂`: Int = `a₂`.apply(`i₂`)
+                {
+                  val `$proxy₂`: FArray$package {
+                    type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+                  } = FArray$package.$asInstanceOf$[FArray$package {
+                    type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+                  }]
+                  val `FArray$package$_this₄`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
+                    type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+                  }]
+                  val `a$proxy₂`: Int = `v₂`.*(100)
 
-          (({
-            val `r₄`: intRepr.type = intRepr
-            new IntOne((`v₂`.*(100): Int))
-          }: FBase): FArray[Int])
-        }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase]
-        val `len₃`: Int = `s₃`.length
-        var `i₃`: Int = 0
-        while (`i₃`.<(`len₃`)) {
-          val `v₃`: Int = FArrayOps.intAt(`s₃`, `i₃`)
-          if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-          `out₂`.update(o, `v₃`)
-          o = o.+(1)
-          `i₃` = `i₃`.+(1)
+                  (({
+                    val `r₄`: intRepr.type = intRepr
+                    new IntOne((`v₂`.*(100): Int))
+                  }: FBase): FArray[Int])
+                }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
+                  case leaf: IntArr =>
+                    val `a₃`: Array[Int] = `leaf₃`.arr
+                    val `len₃`: Int = `a₃`.length
+                    var `i₃`: Int = 0
+                    while (`i₃`.<(`len₃`)) {
+                      val `v₃`: Int = `a₃`.apply(`i₃`)
+                      if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                      `out₂`.update(o, `v₃`)
+                      o = o.+(1)
+                      `i₃` = `i₃`.+(1)
+                    }
+                  case s =>
+                    val `len₄`: Int = s.length
+                    var `i₄`: Int = 0
+                    while (`i₄`.<(`len₄`)) {
+                      val `v₄`: Int = FArrayOps.intAt(s, `i₄`)
+                      if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                      `out₂`.update(o, `v₄`)
+                      o = o.+(1)
+                      `i₄` = `i₄`.+(1)
+                    }
+                }
+                `i₂` = `i₂`.+(1)
+              }
+            case s =>
+              val `len₅`: Int = `s₂`.length
+              var `i₅`: Int = 0
+              while (`i₅`.<(`len₅`)) {
+                val `v₅`: Int = FArrayOps.intAt(`s₂`, `i₅`)
+                {
+                  val `$proxy₃`: FArray$package {
+                    type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+                  } = FArray$package.$asInstanceOf$[FArray$package {
+                    type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+                  }]
+                  val `FArray$package$_this₅`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
+                    type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+                  }]
+                  val `a$proxy₃`: Int = `v₅`.*(100)
+
+                  (({
+                    val `r₅`: intRepr.type = intRepr
+                    new IntOne((`v₅`.*(100): Int))
+                  }: FBase): FArray[Int])
+                }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
+                  case leaf: IntArr =>
+                    val `a₄`: Array[Int] = `leaf₄`.arr
+                    val `len₆`: Int = `a₄`.length
+                    var `i₆`: Int = 0
+                    while (`i₆`.<(`len₆`)) {
+                      val `v₆`: Int = `a₄`.apply(`i₆`)
+                      if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                      `out₂`.update(o, `v₆`)
+                      o = o.+(1)
+                      `i₆` = `i₆`.+(1)
+                    }
+                  case s =>
+                    val `len₇`: Int = `s₃`.length
+                    var `i₇`: Int = 0
+                    while (`i₇`.<(`len₇`)) {
+                      val `v₇`: Int = FArrayOps.intAt(`s₃`, `i₇`)
+                      if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                      `out₂`.update(o, `v₇`)
+                      o = o.+(1)
+                      `i₇` = `i₇`.+(1)
+                    }
+                }
+                `i₅` = `i₅`.+(1)
+              }
+          }
+          i = i.+(1)
         }
-        `i₂` = `i₂`.+(1)
-      }
-      i = i.+(1)
+      case s =>
+        val `len₈`: Int = `s₄`.length
+        var `i₈`: Int = 0
+        while (`i₈`.<(`len₈`)) {
+          val `v₈`: Int = FArrayOps.intAt(`s₄`, `i₈`)
+          {
+            val `$proxy₃`: FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            } = FArray$package.$asInstanceOf$[FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            }]
+            val `FArray$package$_this₆`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            }]
+            val `b$proxy₃`: Int = `v₈`.+(1)
+
+            (({
+              val `r₆`: intRepr.type = intRepr
+              val `out₄`: Array[Int] = new Array[Int](2)
+              `out₄`.update(0, (`v₈`: Int))
+              `out₄`.update(1, (`v₈`.+(1): Int))
+              new IntArr(`out₄`, 2)
+            }: FBase): FArray[Int])
+          }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
+            case leaf: IntArr =>
+              val `a₅`: Array[Int] = `leaf₅`.arr
+              val `len₉`: Int = `a₅`.length
+              var `i₉`: Int = 0
+              while (`i₉`.<(`len₉`)) {
+                val `v₉`: Int = `a₅`.apply(`i₉`)
+                {
+                  val `$proxy₄`: FArray$package {
+                    type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+                  } = FArray$package.$asInstanceOf$[FArray$package {
+                    type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+                  }]
+                  val `FArray$package$_this₇`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
+                    type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+                  }]
+                  val `a$proxy₄`: Int = `v₉`.*(100)
+
+                  (({
+                    val `r₇`: intRepr.type = intRepr
+                    new IntOne((`v₉`.*(100): Int))
+                  }: FBase): FArray[Int])
+                }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
+                  case leaf: IntArr =>
+                    val `a₆`: Array[Int] = `leaf₆`.arr
+                    val `len₁₀`: Int = `a₆`.length
+                    var `i₁₀`: Int = 0
+                    while (`i₁₀`.<(`len₁₀`)) {
+                      val `v₁₀`: Int = `a₆`.apply(`i₁₀`)
+                      if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                      `out₂`.update(o, `v₁₀`)
+                      o = o.+(1)
+                      `i₁₀` = `i₁₀`.+(1)
+                    }
+                  case s =>
+                    val `len₁₁`: Int = `s₅`.length
+                    var `i₁₁`: Int = 0
+                    while (`i₁₁`.<(`len₁₁`)) {
+                      val `v₁₁`: Int = FArrayOps.intAt(`s₅`, `i₁₁`)
+                      if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                      `out₂`.update(o, `v₁₁`)
+                      o = o.+(1)
+                      `i₁₁` = `i₁₁`.+(1)
+                    }
+                }
+                `i₉` = `i₉`.+(1)
+              }
+            case s =>
+              val `len₁₂`: Int = `s₆`.length
+              var `i₁₂`: Int = 0
+              while (`i₁₂`.<(`len₁₂`)) {
+                val `v₁₂`: Int = FArrayOps.intAt(`s₆`, `i₁₂`)
+                {
+                  val `$proxy₅`: FArray$package {
+                    type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+                  } = FArray$package.$asInstanceOf$[FArray$package {
+                    type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+                  }]
+                  val `FArray$package$_this₈`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
+                    type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+                  }]
+                  val `a$proxy₅`: Int = `v₁₂`.*(100)
+
+                  (({
+                    val `r₈`: intRepr.type = intRepr
+                    new IntOne((`v₁₂`.*(100): Int))
+                  }: FBase): FArray[Int])
+                }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
+                  case leaf: IntArr =>
+                    val `a₇`: Array[Int] = `leaf₇`.arr
+                    val `len₁₃`: Int = `a₇`.length
+                    var `i₁₃`: Int = 0
+                    while (`i₁₃`.<(`len₁₃`)) {
+                      val `v₁₃`: Int = `a₇`.apply(`i₁₃`)
+                      if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                      `out₂`.update(o, `v₁₃`)
+                      o = o.+(1)
+                      `i₁₃` = `i₁₃`.+(1)
+                    }
+                  case s =>
+                    val `len₁₄`: Int = `s₇`.length
+                    var `i₁₄`: Int = 0
+                    while (`i₁₄`.<(`len₁₄`)) {
+                      val `v₁₄`: Int = FArrayOps.intAt(`s₇`, `i₁₄`)
+                      if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                      `out₂`.update(o, `v₁₄`)
+                      o = o.+(1)
+                      `i₁₄` = `i₁₄`.+(1)
+                    }
+                }
+                `i₁₂` = `i₁₂`.+(1)
+              }
+          }
+          `i₈` = `i₈`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(`out₂`.apply(0)) else if (o.==(`out₂`.length)) new IntArr(`out₂`, o) else new IntArr(java.util.Arrays.copyOf(`out₂`, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -1409,16 +2165,30 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      val `v₂`: Int = v.+(3)
-      val `v₃`: Int = v.+(`v₂`)
-      out.update(o, `v₃`)
-      o = o.+(1)
-      i = i.+(1)
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len)) {
+          val v: Int = a.apply(i)
+          val `v₂`: Int = v.+(3)
+          val `v₃`: Int = v.+(`v₂`)
+          out.update(o, `v₃`)
+          o = o.+(1)
+          i = i.+(1)
+        }
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`)) {
+          val `v₄`: Int = FArrayOps.intAt(s, `i₂`)
+          val `v₅`: Int = `v₄`.+(3)
+          val `v₆`: Int = `v₄`.+(`v₅`)
+          out.update(o, `v₆`)
+          o = o.+(1)
+          `i₂` = `i₂`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -1457,48 +2227,126 @@
     val n0: Int = src0.length
     var `out₂`: Array[Int] = new Array[Int](java.lang.Math.max(8, n0))
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      val `v₂`: Boolean = v.>(0)
-      if (`v₂`) {
-        val `s₂`: FBase = {
-          val `$proxy₂`: FArray$package {
-            type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-          } = FArray$package.$asInstanceOf$[FArray$package {
-            type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-          }]
-          val `FArray$package$_this₂`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
-            type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-          }]
-          val `b$proxy₂`: Int = v.unary_-
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len)) {
+          val v: Int = a.apply(i)
+          val `v₂`: Boolean = v.>(0)
+          if (`v₂`) {
+            val `$proxy₂`: FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            } = FArray$package.$asInstanceOf$[FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            }]
+            val `FArray$package$_this₂`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            }]
+            val `b$proxy₂`: Int = v.unary_-
 
-          (({
-            val `r₂`: intRepr.type = intRepr
-            val `out₃`: Array[Int] = new Array[Int](2)
-            `out₃`.update(0, (v: Int))
-            `out₃`.update(1, (v.unary_- : Int))
-            new IntArr(`out₃`, 2)
-          }: FBase): FArray[Int])
-        }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase]
-        val `len₂`: Int = `s₂`.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`)) {
-          val `v₃`: Int = FArrayOps.intAt(`s₂`, `i₂`)
-          val `v₄`: Int = `v₃`.%(2)
-          val `v₅`: Boolean = `v₄`.==(0)
-          if (`v₅`) {
-            val `v₆`: Int = `v₃`.+(1)
-            if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-            `out₂`.update(o, `v₆`)
-            o = o.+(1)
+            (({
+              val `r₂`: intRepr.type = intRepr
+              val `out₃`: Array[Int] = new Array[Int](2)
+              `out₃`.update(0, (v: Int))
+              `out₃`.update(1, (v.unary_- : Int))
+              new IntArr(`out₃`, 2)
+            }: FBase): FArray[Int])
+          }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
+            case leaf: IntArr =>
+              val `a₂`: Array[Int] = `leaf₂`.arr
+              val `len₂`: Int = `a₂`.length
+              var `i₂`: Int = 0
+              while (`i₂`.<(`len₂`)) {
+                val `v₃`: Int = `a₂`.apply(`i₂`)
+                val `v₄`: Int = `v₃`.%(2)
+                val `v₅`: Boolean = `v₄`.==(0)
+                if (`v₅`) {
+                  val `v₆`: Int = `v₃`.+(1)
+                  if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                  `out₂`.update(o, `v₆`)
+                  o = o.+(1)
+                } else ()
+                `i₂` = `i₂`.+(1)
+              }
+            case s =>
+              val `len₃`: Int = s.length
+              var `i₃`: Int = 0
+              while (`i₃`.<(`len₃`)) {
+                val `v₇`: Int = FArrayOps.intAt(s, `i₃`)
+                val `v₈`: Int = `v₇`.%(2)
+                val `v₉`: Boolean = `v₈`.==(0)
+                if (`v₉`) {
+                  val `v₁₀`: Int = `v₇`.+(1)
+                  if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                  `out₂`.update(o, `v₁₀`)
+                  o = o.+(1)
+                } else ()
+                `i₃` = `i₃`.+(1)
+              }
           } else ()
-          `i₂` = `i₂`.+(1)
+          i = i.+(1)
         }
-      } else ()
-      i = i.+(1)
+      case s =>
+        val `len₄`: Int = `s₂`.length
+        var `i₄`: Int = 0
+        while (`i₄`.<(`len₄`)) {
+          val `v₁₁`: Int = FArrayOps.intAt(`s₂`, `i₄`)
+          val `v₁₂`: Boolean = `v₁₁`.>(0)
+          if (`v₁₂`) {
+            val `$proxy₃`: FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            } = FArray$package.$asInstanceOf$[FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            }]
+            val `FArray$package$_this₃`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            }]
+            val `b$proxy₃`: Int = `v₁₁`.unary_-
+
+            (({
+              val `r₃`: intRepr.type = intRepr
+              val `out₄`: Array[Int] = new Array[Int](2)
+              `out₄`.update(0, (`v₁₁`: Int))
+              `out₄`.update(1, (`v₁₁`.unary_- : Int))
+              new IntArr(`out₄`, 2)
+            }: FBase): FArray[Int])
+          }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
+            case leaf: IntArr =>
+              val `a₃`: Array[Int] = `leaf₃`.arr
+              val `len₅`: Int = `a₃`.length
+              var `i₅`: Int = 0
+              while (`i₅`.<(`len₅`)) {
+                val `v₁₃`: Int = `a₃`.apply(`i₅`)
+                val `v₁₄`: Int = `v₁₃`.%(2)
+                val `v₁₅`: Boolean = `v₁₄`.==(0)
+                if (`v₁₅`) {
+                  val `v₁₆`: Int = `v₁₃`.+(1)
+                  if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                  `out₂`.update(o, `v₁₆`)
+                  o = o.+(1)
+                } else ()
+                `i₅` = `i₅`.+(1)
+              }
+            case s =>
+              val `len₆`: Int = `s₃`.length
+              var `i₆`: Int = 0
+              while (`i₆`.<(`len₆`)) {
+                val `v₁₇`: Int = FArrayOps.intAt(`s₃`, `i₆`)
+                val `v₁₈`: Int = `v₁₇`.%(2)
+                val `v₁₉`: Boolean = `v₁₈`.==(0)
+                if (`v₁₉`) {
+                  val `v₂₀`: Int = `v₁₇`.+(1)
+                  if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                  `out₂`.update(o, `v₂₀`)
+                  o = o.+(1)
+                } else ()
+                `i₆` = `i₆`.+(1)
+              }
+          } else ()
+          `i₄` = `i₄`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(`out₂`.apply(0)) else if (o.==(`out₂`.length)) new IntArr(`out₂`, o) else new IntArr(java.util.Arrays.copyOf(`out₂`, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -1522,24 +2370,46 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      val `v₂`: Boolean = v.>(1)
-      if (`v₂`) {
-        val `v₃`: Boolean = v.<(7)
-        if (`v₃`) {
-          val `v₄`: Int = v.%(2)
-          val `v₅`: Boolean = `v₄`.==(0)
-          if (`v₅`) {
-            out.update(o, v)
-            o = o.+(1)
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len)) {
+          val v: Int = a.apply(i)
+          val `v₂`: Boolean = v.>(1)
+          if (`v₂`) {
+            val `v₃`: Boolean = v.<(7)
+            if (`v₃`) {
+              val `v₄`: Int = v.%(2)
+              val `v₅`: Boolean = `v₄`.==(0)
+              if (`v₅`) {
+                out.update(o, v)
+                o = o.+(1)
+              } else ()
+            } else ()
           } else ()
-        } else ()
-      } else ()
-      i = i.+(1)
+          i = i.+(1)
+        }
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`)) {
+          val `v₆`: Int = FArrayOps.intAt(s, `i₂`)
+          val `v₇`: Boolean = `v₆`.>(1)
+          if (`v₇`) {
+            val `v₈`: Boolean = `v₆`.<(7)
+            if (`v₈`) {
+              val `v₉`: Int = `v₆`.%(2)
+              val `v₁₀`: Boolean = `v₉`.==(0)
+              if (`v₁₀`) {
+                out.update(o, `v₆`)
+                o = o.+(1)
+              } else ()
+            } else ()
+          } else ()
+          `i₂` = `i₂`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -1563,19 +2433,36 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      val `v₂`: Int = v.%(3)
-      val `v₃`: Boolean = `v₂`.==(0)
-      if (`v₃`) {
-        val `v₄`: Int = v.*(7)
-        out.update(o, `v₄`)
-        o = o.+(1)
-      } else ()
-      i = i.+(1)
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len)) {
+          val v: Int = a.apply(i)
+          val `v₂`: Int = v.%(3)
+          val `v₃`: Boolean = `v₂`.==(0)
+          if (`v₃`) {
+            val `v₄`: Int = v.*(7)
+            out.update(o, `v₄`)
+            o = o.+(1)
+          } else ()
+          i = i.+(1)
+        }
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`)) {
+          val `v₅`: Int = FArrayOps.intAt(s, `i₂`)
+          val `v₆`: Int = `v₅`.%(3)
+          val `v₇`: Boolean = `v₆`.==(0)
+          if (`v₇`) {
+            val `v₈`: Int = `v₅`.*(7)
+            out.update(o, `v₈`)
+            o = o.+(1)
+          } else ()
+          `i₂` = `i₂`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -1606,23 +2493,44 @@
     val cap: Int = java.lang.Math.min(n0, lim)
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len).&&(done.unary_!)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      val `v₂`: Int = v.%(2)
-      val `v₃`: Boolean = `v₂`.==(0)
-      if (`v₃`) {
-        val cv: Int = c
-        if (cv.>=(lim)) done = true else {
-          out.update(o, v)
-          o = o.+(1)
-          c = c.+(1)
-          if (cv.+(1).>=(lim)) done = true else ()
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len).&&(done.unary_!)) {
+          val v: Int = a.apply(i)
+          val `v₂`: Int = v.%(2)
+          val `v₃`: Boolean = `v₂`.==(0)
+          if (`v₃`) {
+            val cv: Int = c
+            if (cv.>=(lim)) done = true else {
+              out.update(o, v)
+              o = o.+(1)
+              c = c.+(1)
+              if (cv.+(1).>=(lim)) done = true else ()
+            }
+          } else ()
+          i = i.+(1)
         }
-      } else ()
-      i = i.+(1)
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
+          val `v₄`: Int = FArrayOps.intAt(s, `i₂`)
+          val `v₅`: Int = `v₄`.%(2)
+          val `v₆`: Boolean = `v₅`.==(0)
+          if (`v₆`) {
+            val `cv₂`: Int = c
+            if (`cv₂`.>=(lim)) done = true else {
+              out.update(o, `v₄`)
+              o = o.+(1)
+              c = c.+(1)
+              if (`cv₂`.+(1).>=(lim)) done = true else ()
+            }
+          } else ()
+          `i₂` = `i₂`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -1668,45 +2576,124 @@
     var c: Int = 0
     var `out₂`: Array[Int] = new Array[Int](java.lang.Math.max(8, n0))
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len).&&(done.unary_!)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      val `s₂`: FBase = {
-        val `$proxy₂`: FArray$package {
-          type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-        } = FArray$package.$asInstanceOf$[FArray$package {
-          type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-        }]
-        val `FArray$package$_this₂`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
-          type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-        }]
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len).&&(done.unary_!)) {
+          val v: Int = a.apply(i)
+          {
+            val `$proxy₂`: FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            } = FArray$package.$asInstanceOf$[FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            }]
+            val `FArray$package$_this₂`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            }]
 
-        (({
-          val `r₂`: intRepr.type = intRepr
-          val `out₃`: Array[Int] = new Array[Int](3)
-          `out₃`.update(0, (v: Int))
-          `out₃`.update(1, (v: Int))
-          `out₃`.update(2, (v: Int))
-          new IntArr(`out₃`, 3)
-        }: FBase): FArray[Int])
-      }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase]
-      val `len₂`: Int = `s₂`.length
-      var `i₂`: Int = 0
-      while (`i₂`.<(`len₂`).&&(done.unary_!)) {
-        val `v₂`: Int = FArrayOps.intAt(`s₂`, `i₂`)
-        val cv: Int = c
-        if (cv.>=(lim)) done = true else {
-          if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-          `out₂`.update(o, `v₂`)
-          o = o.+(1)
-          c = c.+(1)
-          if (cv.+(1).>=(lim)) done = true else ()
+            (({
+              val `r₂`: intRepr.type = intRepr
+              val `out₃`: Array[Int] = new Array[Int](3)
+              `out₃`.update(0, (v: Int))
+              `out₃`.update(1, (v: Int))
+              `out₃`.update(2, (v: Int))
+              new IntArr(`out₃`, 3)
+            }: FBase): FArray[Int])
+          }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
+            case leaf: IntArr =>
+              val `a₂`: Array[Int] = `leaf₂`.arr
+              val `len₂`: Int = `a₂`.length
+              var `i₂`: Int = 0
+              while (`i₂`.<(`len₂`).&&(done.unary_!)) {
+                val `v₂`: Int = `a₂`.apply(`i₂`)
+                val cv: Int = c
+                if (cv.>=(lim)) done = true else {
+                  if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                  `out₂`.update(o, `v₂`)
+                  o = o.+(1)
+                  c = c.+(1)
+                  if (cv.+(1).>=(lim)) done = true else ()
+                }
+                `i₂` = `i₂`.+(1)
+              }
+            case s =>
+              val `len₃`: Int = s.length
+              var `i₃`: Int = 0
+              while (`i₃`.<(`len₃`).&&(done.unary_!)) {
+                val `v₃`: Int = FArrayOps.intAt(s, `i₃`)
+                val `cv₂`: Int = c
+                if (`cv₂`.>=(lim)) done = true else {
+                  if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                  `out₂`.update(o, `v₃`)
+                  o = o.+(1)
+                  c = c.+(1)
+                  if (`cv₂`.+(1).>=(lim)) done = true else ()
+                }
+                `i₃` = `i₃`.+(1)
+              }
+          }
+          i = i.+(1)
         }
-        `i₂` = `i₂`.+(1)
-      }
-      i = i.+(1)
+      case s =>
+        val `len₄`: Int = `s₂`.length
+        var `i₄`: Int = 0
+        while (`i₄`.<(`len₄`).&&(done.unary_!)) {
+          val `v₄`: Int = FArrayOps.intAt(`s₂`, `i₄`)
+          {
+            val `$proxy₃`: FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            } = FArray$package.$asInstanceOf$[FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            }]
+            val `FArray$package$_this₃`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
+              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+            }]
+
+            (({
+              val `r₃`: intRepr.type = intRepr
+              val `out₄`: Array[Int] = new Array[Int](3)
+              `out₄`.update(0, (`v₄`: Int))
+              `out₄`.update(1, (`v₄`: Int))
+              `out₄`.update(2, (`v₄`: Int))
+              new IntArr(`out₄`, 3)
+            }: FBase): FArray[Int])
+          }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
+            case leaf: IntArr =>
+              val `a₃`: Array[Int] = `leaf₃`.arr
+              val `len₅`: Int = `a₃`.length
+              var `i₅`: Int = 0
+              while (`i₅`.<(`len₅`).&&(done.unary_!)) {
+                val `v₅`: Int = `a₃`.apply(`i₅`)
+                val `cv₃`: Int = c
+                if (`cv₃`.>=(lim)) done = true else {
+                  if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                  `out₂`.update(o, `v₅`)
+                  o = o.+(1)
+                  c = c.+(1)
+                  if (`cv₃`.+(1).>=(lim)) done = true else ()
+                }
+                `i₅` = `i₅`.+(1)
+              }
+            case s =>
+              val `len₆`: Int = `s₃`.length
+              var `i₆`: Int = 0
+              while (`i₆`.<(`len₆`).&&(done.unary_!)) {
+                val `v₆`: Int = FArrayOps.intAt(`s₃`, `i₆`)
+                val `cv₄`: Int = c
+                if (`cv₄`.>=(lim)) done = true else {
+                  if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                  `out₂`.update(o, `v₆`)
+                  o = o.+(1)
+                  c = c.+(1)
+                  if (`cv₄`.+(1).>=(lim)) done = true else ()
+                }
+                `i₆` = `i₆`.+(1)
+              }
+          }
+          `i₄` = `i₄`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(`out₂`.apply(0)) else if (o.==(`out₂`.length)) new IntArr(`out₂`, o) else new IntArr(java.util.Arrays.copyOf(`out₂`, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -1738,25 +2725,48 @@
     val cap: Int = java.lang.Math.min(n0, lim)
     val out: Array[Object] = new Array[Object](cap)
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len).&&(done.unary_!)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      val `v₂`: Int = v.%(2)
-      val `v₃`: Boolean = `v₂`.==(0)
-      if (`v₃`) {
-        val `v₄`: Int = c
-        c = c.+(1)
-        val cv: Int = `c₂`
-        if (cv.>=(lim)) done = true else {
-          out.update(o, new Tuple2$mcII$sp(v, `v₄`).asInstanceOf[Tuple2[Int, Int]].asInstanceOf[Object])
-          o = o.+(1)
-          `c₂` = `c₂`.+(1)
-          if (cv.+(1).>=(lim)) done = true else ()
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len).&&(done.unary_!)) {
+          val v: Int = a.apply(i)
+          val `v₂`: Int = v.%(2)
+          val `v₃`: Boolean = `v₂`.==(0)
+          if (`v₃`) {
+            val `v₄`: Int = c
+            c = c.+(1)
+            val cv: Int = `c₂`
+            if (cv.>=(lim)) done = true else {
+              out.update(o, new Tuple2$mcII$sp(v, `v₄`).asInstanceOf[Tuple2[Int, Int]].asInstanceOf[Object])
+              o = o.+(1)
+              `c₂` = `c₂`.+(1)
+              if (cv.+(1).>=(lim)) done = true else ()
+            }
+          } else ()
+          i = i.+(1)
         }
-      } else ()
-      i = i.+(1)
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
+          val `v₅`: Int = FArrayOps.intAt(s, `i₂`)
+          val `v₆`: Int = `v₅`.%(2)
+          val `v₇`: Boolean = `v₆`.==(0)
+          if (`v₇`) {
+            val `v₈`: Int = c
+            c = c.+(1)
+            val `cv₂`: Int = `c₂`
+            if (`cv₂`.>=(lim)) done = true else {
+              out.update(o, new Tuple2$mcII$sp(`v₅`, `v₈`).asInstanceOf[Tuple2[Int, Int]].asInstanceOf[Object])
+              o = o.+(1)
+              `c₂` = `c₂`.+(1)
+              if (`cv₂`.+(1).>=(lim)) done = true else ()
+            }
+          } else ()
+          `i₂` = `i₂`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new RefOne(out.apply(0)) else if (o.==(cap)) new RefArr(out, o) else new RefArr(java.util.Arrays.copyOf[Object](out, o), o)
   }.asInstanceOf[FArray[Tuple2[Int, Int]]]: FArray[Tuple2[Int, Int]])
@@ -1788,25 +2798,48 @@
     val cap: Int = java.lang.Math.min(n0, lim)
     val out: Array[Object] = new Array[Object](cap)
     var o: Int = 0
-    val s: FBase = src0
-    val len: Int = s.length
-    var i: Int = 0
-    while (i.<(len).&&(done.unary_!)) {
-      val v: Int = FArrayOps.intAt(s, i)
-      val `v₂`: Int = c
-      c = c.+(1)
-      val `v₃`: Int = v.%(2)
-      val `v₄`: Boolean = `v₃`.==(0)
-      if (`v₄`) {
-        val cv: Int = `c₂`
-        if (cv.>=(lim)) done = true else {
-          out.update(o, new Tuple2$mcII$sp(v, `v₂`).asInstanceOf[Tuple2[Int, Int]].asInstanceOf[Object])
-          o = o.+(1)
-          `c₂` = `c₂`.+(1)
-          if (cv.+(1).>=(lim)) done = true else ()
+    src0 match {
+      case leaf: IntArr =>
+        val a: Array[Int] = leaf.arr
+        val len: Int = a.length
+        var i: Int = 0
+        while (i.<(len).&&(done.unary_!)) {
+          val v: Int = a.apply(i)
+          val `v₂`: Int = c
+          c = c.+(1)
+          val `v₃`: Int = v.%(2)
+          val `v₄`: Boolean = `v₃`.==(0)
+          if (`v₄`) {
+            val cv: Int = `c₂`
+            if (cv.>=(lim)) done = true else {
+              out.update(o, new Tuple2$mcII$sp(v, `v₂`).asInstanceOf[Tuple2[Int, Int]].asInstanceOf[Object])
+              o = o.+(1)
+              `c₂` = `c₂`.+(1)
+              if (cv.+(1).>=(lim)) done = true else ()
+            }
+          } else ()
+          i = i.+(1)
         }
-      } else ()
-      i = i.+(1)
+      case s =>
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
+          val `v₅`: Int = FArrayOps.intAt(s, `i₂`)
+          val `v₆`: Int = c
+          c = c.+(1)
+          val `v₇`: Int = `v₅`.%(2)
+          val `v₈`: Boolean = `v₇`.==(0)
+          if (`v₈`) {
+            val `cv₂`: Int = `c₂`
+            if (`cv₂`.>=(lim)) done = true else {
+              out.update(o, new Tuple2$mcII$sp(`v₅`, `v₆`).asInstanceOf[Tuple2[Int, Int]].asInstanceOf[Object])
+              o = o.+(1)
+              `c₂` = `c₂`.+(1)
+              if (`cv₂`.+(1).>=(lim)) done = true else ()
+            }
+          } else ()
+          `i₂` = `i₂`.+(1)
+        }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new RefOne(out.apply(0)) else if (o.==(cap)) new RefArr(out, o) else new RefArr(java.util.Arrays.copyOf[Object](out, o), o)
   }.asInstanceOf[FArray[Tuple2[Int, Int]]]: FArray[Tuple2[Int, Int]])

--- a/tests/snapshots/fused-pipeline.snap
+++ b/tests/snapshots/fused-pipeline.snap
@@ -485,100 +485,32 @@
         var i: Int = 0
         while (i.<(len)) {
           val v: Int = a.apply(i)
-          {
-            val `$proxy₂`: FArray$package {
-              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-            } = FArray$package.$asInstanceOf$[FArray$package {
-              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-            }]
-            val `FArray$package$_this₂`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
-              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-            }]
-            val `b$proxy₂`: Int = v.*(10)
-
-            (({
-              val `r₂`: intRepr.type = intRepr
-              val `out₃`: Array[Int] = new Array[Int](2)
-              `out₃`.update(0, (v: Int))
-              `out₃`.update(1, (v.*(10): Int))
-              new IntArr(`out₃`, 2)
-            }: FBase): FArray[Int])
-          }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
-            case leaf: IntArr =>
-              val `a₂`: Array[Int] = `leaf₂`.arr
-              val `len₂`: Int = `a₂`.length
-              var `i₂`: Int = 0
-              while (`i₂`.<(`len₂`)) {
-                val `v₂`: Int = `a₂`.apply(`i₂`)
-                val `v₃`: Int = `v₂`.+(1)
-                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                `out₂`.update(o, `v₃`)
-                o = o.+(1)
-                `i₂` = `i₂`.+(1)
-              }
-            case s =>
-              val `len₃`: Int = s.length
-              var `i₃`: Int = 0
-              while (`i₃`.<(`len₃`)) {
-                val `v₄`: Int = FArrayOps.intAt(s, `i₃`)
-                val `v₅`: Int = `v₄`.+(1)
-                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                `out₂`.update(o, `v₅`)
-                o = o.+(1)
-                `i₃` = `i₃`.+(1)
-              }
-          }
+          val `v₂`: Int = v.+(1)
+          if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+          `out₂`.update(o, `v₂`)
+          o = o.+(1)
+          val `v₃`: Int = v.*(10)
+          val `v₄`: Int = `v₃`.+(1)
+          if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+          `out₂`.update(o, `v₄`)
+          o = o.+(1)
           i = i.+(1)
         }
       case s =>
-        val `len₄`: Int = `s₂`.length
-        var `i₄`: Int = 0
-        while (`i₄`.<(`len₄`)) {
-          val `v₆`: Int = FArrayOps.intAt(`s₂`, `i₄`)
-          {
-            val `$proxy₃`: FArray$package {
-              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-            } = FArray$package.$asInstanceOf$[FArray$package {
-              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-            }]
-            val `FArray$package$_this₃`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
-              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-            }]
-            val `b$proxy₃`: Int = `v₆`.*(10)
-
-            (({
-              val `r₃`: intRepr.type = intRepr
-              val `out₄`: Array[Int] = new Array[Int](2)
-              `out₄`.update(0, (`v₆`: Int))
-              `out₄`.update(1, (`v₆`.*(10): Int))
-              new IntArr(`out₄`, 2)
-            }: FBase): FArray[Int])
-          }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
-            case leaf: IntArr =>
-              val `a₃`: Array[Int] = `leaf₃`.arr
-              val `len₅`: Int = `a₃`.length
-              var `i₅`: Int = 0
-              while (`i₅`.<(`len₅`)) {
-                val `v₇`: Int = `a₃`.apply(`i₅`)
-                val `v₈`: Int = `v₇`.+(1)
-                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                `out₂`.update(o, `v₈`)
-                o = o.+(1)
-                `i₅` = `i₅`.+(1)
-              }
-            case s =>
-              val `len₆`: Int = `s₃`.length
-              var `i₆`: Int = 0
-              while (`i₆`.<(`len₆`)) {
-                val `v₉`: Int = FArrayOps.intAt(`s₃`, `i₆`)
-                val `v₁₀`: Int = `v₉`.+(1)
-                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                `out₂`.update(o, `v₁₀`)
-                o = o.+(1)
-                `i₆` = `i₆`.+(1)
-              }
-          }
-          `i₄` = `i₄`.+(1)
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`)) {
+          val `v₅`: Int = FArrayOps.intAt(s, `i₂`)
+          val `v₆`: Int = `v₅`.+(1)
+          if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+          `out₂`.update(o, `v₆`)
+          o = o.+(1)
+          val `v₇`: Int = `v₅`.*(10)
+          val `v₈`: Int = `v₇`.+(1)
+          if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+          `out₂`.update(o, `v₈`)
+          o = o.+(1)
+          `i₂` = `i₂`.+(1)
         }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(`out₂`.apply(0)) else if (o.==(`out₂`.length)) new IntArr(`out₂`, o) else new IntArr(java.util.Arrays.copyOf(`out₂`, o), o)
@@ -1758,100 +1690,32 @@
         var i: Int = 0
         while (i.<(len)) {
           val v: Int = a.apply(i)
-          {
-            val `$proxy₂`: FArray$package {
-              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-            } = FArray$package.$asInstanceOf$[FArray$package {
-              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-            }]
-            val `FArray$package$_this₂`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
-              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-            }]
-            val `b$proxy₂`: Int = v.*(10)
-
-            (({
-              val `r₂`: intRepr.type = intRepr
-              val `out₃`: Array[Int] = new Array[Int](2)
-              `out₃`.update(0, (v: Int))
-              `out₃`.update(1, (v.*(10): Int))
-              new IntArr(`out₃`, 2)
-            }: FBase): FArray[Int])
-          }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
-            case leaf: IntArr =>
-              val `a₂`: Array[Int] = `leaf₂`.arr
-              val `len₂`: Int = `a₂`.length
-              var `i₂`: Int = 0
-              while (`i₂`.<(`len₂`)) {
-                val `v₂`: Int = `a₂`.apply(`i₂`)
-                val `v₃`: Int = `v₂`.+(1)
-                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                `out₂`.update(o, `v₃`)
-                o = o.+(1)
-                `i₂` = `i₂`.+(1)
-              }
-            case s =>
-              val `len₃`: Int = s.length
-              var `i₃`: Int = 0
-              while (`i₃`.<(`len₃`)) {
-                val `v₄`: Int = FArrayOps.intAt(s, `i₃`)
-                val `v₅`: Int = `v₄`.+(1)
-                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                `out₂`.update(o, `v₅`)
-                o = o.+(1)
-                `i₃` = `i₃`.+(1)
-              }
-          }
+          val `v₂`: Int = v.+(1)
+          if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+          `out₂`.update(o, `v₂`)
+          o = o.+(1)
+          val `v₃`: Int = v.*(10)
+          val `v₄`: Int = `v₃`.+(1)
+          if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+          `out₂`.update(o, `v₄`)
+          o = o.+(1)
           i = i.+(1)
         }
       case s =>
-        val `len₄`: Int = `s₂`.length
-        var `i₄`: Int = 0
-        while (`i₄`.<(`len₄`)) {
-          val `v₆`: Int = FArrayOps.intAt(`s₂`, `i₄`)
-          {
-            val `$proxy₃`: FArray$package {
-              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-            } = FArray$package.$asInstanceOf$[FArray$package {
-              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-            }]
-            val `FArray$package$_this₃`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
-              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-            }]
-            val `b$proxy₃`: Int = `v₆`.*(10)
-
-            (({
-              val `r₃`: intRepr.type = intRepr
-              val `out₄`: Array[Int] = new Array[Int](2)
-              `out₄`.update(0, (`v₆`: Int))
-              `out₄`.update(1, (`v₆`.*(10): Int))
-              new IntArr(`out₄`, 2)
-            }: FBase): FArray[Int])
-          }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
-            case leaf: IntArr =>
-              val `a₃`: Array[Int] = `leaf₃`.arr
-              val `len₅`: Int = `a₃`.length
-              var `i₅`: Int = 0
-              while (`i₅`.<(`len₅`)) {
-                val `v₇`: Int = `a₃`.apply(`i₅`)
-                val `v₈`: Int = `v₇`.+(1)
-                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                `out₂`.update(o, `v₈`)
-                o = o.+(1)
-                `i₅` = `i₅`.+(1)
-              }
-            case s =>
-              val `len₆`: Int = `s₃`.length
-              var `i₆`: Int = 0
-              while (`i₆`.<(`len₆`)) {
-                val `v₉`: Int = FArrayOps.intAt(`s₃`, `i₆`)
-                val `v₁₀`: Int = `v₉`.+(1)
-                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                `out₂`.update(o, `v₁₀`)
-                o = o.+(1)
-                `i₆` = `i₆`.+(1)
-              }
-          }
-          `i₄` = `i₄`.+(1)
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`)) {
+          val `v₅`: Int = FArrayOps.intAt(s, `i₂`)
+          val `v₆`: Int = `v₅`.+(1)
+          if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+          `out₂`.update(o, `v₆`)
+          o = o.+(1)
+          val `v₇`: Int = `v₅`.*(10)
+          val `v₈`: Int = `v₇`.+(1)
+          if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+          `out₂`.update(o, `v₈`)
+          o = o.+(1)
+          `i₂` = `i₂`.+(1)
         }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(`out₂`.apply(0)) else if (o.==(`out₂`.length)) new IntArr(`out₂`, o) else new IntArr(java.util.Arrays.copyOf(`out₂`, o), o)
@@ -1920,14 +1784,11 @@
             val `FArray$package$_this₃`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
               type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
             }]
-            val `b$proxy₂`: Int = v.+(1)
+            val `a$proxy₂`: Int = v.*(100)
 
             (({
               val `r₃`: intRepr.type = intRepr
-              val `out₃`: Array[Int] = new Array[Int](2)
-              `out₃`.update(0, (v: Int))
-              `out₃`.update(1, (v.+(1): Int))
-              new IntArr(`out₃`, 2)
+              new IntOne((v.*(100): Int))
             }: FBase): FArray[Int])
           }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
             case leaf: IntArr =>
@@ -1936,211 +1797,152 @@
               var `i₂`: Int = 0
               while (`i₂`.<(`len₂`)) {
                 val `v₂`: Int = `a₂`.apply(`i₂`)
-                {
-                  val `$proxy₂`: FArray$package {
-                    type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-                  } = FArray$package.$asInstanceOf$[FArray$package {
-                    type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-                  }]
-                  val `FArray$package$_this₄`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
-                    type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-                  }]
-                  val `a$proxy₂`: Int = `v₂`.*(100)
-
-                  (({
-                    val `r₄`: intRepr.type = intRepr
-                    new IntOne((`v₂`.*(100): Int))
-                  }: FBase): FArray[Int])
-                }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
-                  case leaf: IntArr =>
-                    val `a₃`: Array[Int] = `leaf₃`.arr
-                    val `len₃`: Int = `a₃`.length
-                    var `i₃`: Int = 0
-                    while (`i₃`.<(`len₃`)) {
-                      val `v₃`: Int = `a₃`.apply(`i₃`)
-                      if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                      `out₂`.update(o, `v₃`)
-                      o = o.+(1)
-                      `i₃` = `i₃`.+(1)
-                    }
-                  case s =>
-                    val `len₄`: Int = s.length
-                    var `i₄`: Int = 0
-                    while (`i₄`.<(`len₄`)) {
-                      val `v₄`: Int = FArrayOps.intAt(s, `i₄`)
-                      if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                      `out₂`.update(o, `v₄`)
-                      o = o.+(1)
-                      `i₄` = `i₄`.+(1)
-                    }
-                }
+                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                `out₂`.update(o, `v₂`)
+                o = o.+(1)
                 `i₂` = `i₂`.+(1)
+              }
+            case s =>
+              val `len₃`: Int = s.length
+              var `i₃`: Int = 0
+              while (`i₃`.<(`len₃`)) {
+                val `v₃`: Int = FArrayOps.intAt(s, `i₃`)
+                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                `out₂`.update(o, `v₃`)
+                o = o.+(1)
+                `i₃` = `i₃`.+(1)
+              }
+          }
+          {
+            val `y₂`: Int = v.+(1)
+
+            {
+              val `$proxy₃`: FArray$package {
+                type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+              } = FArray$package.$asInstanceOf$[FArray$package {
+                type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+              }]
+              val `FArray$package$_this₄`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
+                type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+              }]
+              val `a$proxy₃`: Int = `y₂`.*(100)
+
+              (({
+                val `r₄`: intRepr.type = intRepr
+                new IntOne((`y₂`.*(100): Int))
+              }: FBase): FArray[Int])
+            }.$asInstanceOf$[FArray[Int]]
+          }.asInstanceOf[FBase] match {
+            case leaf: IntArr =>
+              val `a₃`: Array[Int] = `leaf₃`.arr
+              val `len₄`: Int = `a₃`.length
+              var `i₄`: Int = 0
+              while (`i₄`.<(`len₄`)) {
+                val `v₄`: Int = `a₃`.apply(`i₄`)
+                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                `out₂`.update(o, `v₄`)
+                o = o.+(1)
+                `i₄` = `i₄`.+(1)
               }
             case s =>
               val `len₅`: Int = `s₂`.length
               var `i₅`: Int = 0
               while (`i₅`.<(`len₅`)) {
                 val `v₅`: Int = FArrayOps.intAt(`s₂`, `i₅`)
-                {
-                  val `$proxy₃`: FArray$package {
-                    type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-                  } = FArray$package.$asInstanceOf$[FArray$package {
-                    type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-                  }]
-                  val `FArray$package$_this₅`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
-                    type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-                  }]
-                  val `a$proxy₃`: Int = `v₅`.*(100)
-
-                  (({
-                    val `r₅`: intRepr.type = intRepr
-                    new IntOne((`v₅`.*(100): Int))
-                  }: FBase): FArray[Int])
-                }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
-                  case leaf: IntArr =>
-                    val `a₄`: Array[Int] = `leaf₄`.arr
-                    val `len₆`: Int = `a₄`.length
-                    var `i₆`: Int = 0
-                    while (`i₆`.<(`len₆`)) {
-                      val `v₆`: Int = `a₄`.apply(`i₆`)
-                      if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                      `out₂`.update(o, `v₆`)
-                      o = o.+(1)
-                      `i₆` = `i₆`.+(1)
-                    }
-                  case s =>
-                    val `len₇`: Int = `s₃`.length
-                    var `i₇`: Int = 0
-                    while (`i₇`.<(`len₇`)) {
-                      val `v₇`: Int = FArrayOps.intAt(`s₃`, `i₇`)
-                      if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                      `out₂`.update(o, `v₇`)
-                      o = o.+(1)
-                      `i₇` = `i₇`.+(1)
-                    }
-                }
+                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                `out₂`.update(o, `v₅`)
+                o = o.+(1)
                 `i₅` = `i₅`.+(1)
               }
           }
           i = i.+(1)
         }
       case s =>
-        val `len₈`: Int = `s₄`.length
-        var `i₈`: Int = 0
-        while (`i₈`.<(`len₈`)) {
-          val `v₈`: Int = FArrayOps.intAt(`s₄`, `i₈`)
+        val `len₆`: Int = `s₃`.length
+        var `i₆`: Int = 0
+        while (`i₆`.<(`len₆`)) {
+          val `v₆`: Int = FArrayOps.intAt(`s₃`, `i₆`)
           {
-            val `$proxy₃`: FArray$package {
+            val `$proxy₄`: FArray$package {
               type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
             } = FArray$package.$asInstanceOf$[FArray$package {
               type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
             }]
-            val `FArray$package$_this₆`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
+            val `FArray$package$_this₅`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
               type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
             }]
-            val `b$proxy₃`: Int = `v₈`.+(1)
+            val `a$proxy₄`: Int = `v₆`.*(100)
 
             (({
-              val `r₆`: intRepr.type = intRepr
-              val `out₄`: Array[Int] = new Array[Int](2)
-              `out₄`.update(0, (`v₈`: Int))
-              `out₄`.update(1, (`v₈`.+(1): Int))
-              new IntArr(`out₄`, 2)
+              val `r₅`: intRepr.type = intRepr
+              new IntOne((`v₆`.*(100): Int))
             }: FBase): FArray[Int])
           }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
+            case leaf: IntArr =>
+              val `a₄`: Array[Int] = `leaf₄`.arr
+              val `len₇`: Int = `a₄`.length
+              var `i₇`: Int = 0
+              while (`i₇`.<(`len₇`)) {
+                val `v₇`: Int = `a₄`.apply(`i₇`)
+                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                `out₂`.update(o, `v₇`)
+                o = o.+(1)
+                `i₇` = `i₇`.+(1)
+              }
+            case s =>
+              val `len₈`: Int = `s₄`.length
+              var `i₈`: Int = 0
+              while (`i₈`.<(`len₈`)) {
+                val `v₈`: Int = FArrayOps.intAt(`s₄`, `i₈`)
+                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                `out₂`.update(o, `v₈`)
+                o = o.+(1)
+                `i₈` = `i₈`.+(1)
+              }
+          }
+          {
+            val `y₃`: Int = `v₆`.+(1)
+
+            {
+              val `$proxy₅`: FArray$package {
+                type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+              } = FArray$package.$asInstanceOf$[FArray$package {
+                type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+              }]
+              val `FArray$package$_this₆`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
+                type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+              }]
+              val `a$proxy₅`: Int = `y₃`.*(100)
+
+              (({
+                val `r₆`: intRepr.type = intRepr
+                new IntOne((`y₃`.*(100): Int))
+              }: FBase): FArray[Int])
+            }.$asInstanceOf$[FArray[Int]]
+          }.asInstanceOf[FBase] match {
             case leaf: IntArr =>
               val `a₅`: Array[Int] = `leaf₅`.arr
               val `len₉`: Int = `a₅`.length
               var `i₉`: Int = 0
               while (`i₉`.<(`len₉`)) {
                 val `v₉`: Int = `a₅`.apply(`i₉`)
-                {
-                  val `$proxy₄`: FArray$package {
-                    type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-                  } = FArray$package.$asInstanceOf$[FArray$package {
-                    type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-                  }]
-                  val `FArray$package$_this₇`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
-                    type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-                  }]
-                  val `a$proxy₄`: Int = `v₉`.*(100)
-
-                  (({
-                    val `r₇`: intRepr.type = intRepr
-                    new IntOne((`v₉`.*(100): Int))
-                  }: FBase): FArray[Int])
-                }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
-                  case leaf: IntArr =>
-                    val `a₆`: Array[Int] = `leaf₆`.arr
-                    val `len₁₀`: Int = `a₆`.length
-                    var `i₁₀`: Int = 0
-                    while (`i₁₀`.<(`len₁₀`)) {
-                      val `v₁₀`: Int = `a₆`.apply(`i₁₀`)
-                      if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                      `out₂`.update(o, `v₁₀`)
-                      o = o.+(1)
-                      `i₁₀` = `i₁₀`.+(1)
-                    }
-                  case s =>
-                    val `len₁₁`: Int = `s₅`.length
-                    var `i₁₁`: Int = 0
-                    while (`i₁₁`.<(`len₁₁`)) {
-                      val `v₁₁`: Int = FArrayOps.intAt(`s₅`, `i₁₁`)
-                      if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                      `out₂`.update(o, `v₁₁`)
-                      o = o.+(1)
-                      `i₁₁` = `i₁₁`.+(1)
-                    }
-                }
+                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                `out₂`.update(o, `v₉`)
+                o = o.+(1)
                 `i₉` = `i₉`.+(1)
               }
             case s =>
-              val `len₁₂`: Int = `s₆`.length
-              var `i₁₂`: Int = 0
-              while (`i₁₂`.<(`len₁₂`)) {
-                val `v₁₂`: Int = FArrayOps.intAt(`s₆`, `i₁₂`)
-                {
-                  val `$proxy₅`: FArray$package {
-                    type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-                  } = FArray$package.$asInstanceOf$[FArray$package {
-                    type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-                  }]
-                  val `FArray$package$_this₈`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
-                    type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-                  }]
-                  val `a$proxy₅`: Int = `v₁₂`.*(100)
-
-                  (({
-                    val `r₈`: intRepr.type = intRepr
-                    new IntOne((`v₁₂`.*(100): Int))
-                  }: FBase): FArray[Int])
-                }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
-                  case leaf: IntArr =>
-                    val `a₇`: Array[Int] = `leaf₇`.arr
-                    val `len₁₃`: Int = `a₇`.length
-                    var `i₁₃`: Int = 0
-                    while (`i₁₃`.<(`len₁₃`)) {
-                      val `v₁₃`: Int = `a₇`.apply(`i₁₃`)
-                      if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                      `out₂`.update(o, `v₁₃`)
-                      o = o.+(1)
-                      `i₁₃` = `i₁₃`.+(1)
-                    }
-                  case s =>
-                    val `len₁₄`: Int = `s₇`.length
-                    var `i₁₄`: Int = 0
-                    while (`i₁₄`.<(`len₁₄`)) {
-                      val `v₁₄`: Int = FArrayOps.intAt(`s₇`, `i₁₄`)
-                      if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                      `out₂`.update(o, `v₁₄`)
-                      o = o.+(1)
-                      `i₁₄` = `i₁₄`.+(1)
-                    }
-                }
-                `i₁₂` = `i₁₂`.+(1)
+              val `len₁₀`: Int = `s₅`.length
+              var `i₁₀`: Int = 0
+              while (`i₁₀`.<(`len₁₀`)) {
+                val `v₁₀`: Int = FArrayOps.intAt(`s₅`, `i₁₀`)
+                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+                `out₂`.update(o, `v₁₀`)
+                o = o.+(1)
+                `i₁₀` = `i₁₀`.+(1)
               }
           }
-          `i₈` = `i₈`.+(1)
+          `i₆` = `i₆`.+(1)
         }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(`out₂`.apply(0)) else if (o.==(`out₂`.length)) new IntArr(`out₂`, o) else new IntArr(java.util.Arrays.copyOf(`out₂`, o), o)
@@ -2236,116 +2038,56 @@
           val v: Int = a.apply(i)
           val `v₂`: Boolean = v.>(0)
           if (`v₂`) {
-            val `$proxy₂`: FArray$package {
-              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-            } = FArray$package.$asInstanceOf$[FArray$package {
-              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-            }]
-            val `FArray$package$_this₂`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
-              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-            }]
-            val `b$proxy₂`: Int = v.unary_-
-
-            (({
-              val `r₂`: intRepr.type = intRepr
-              val `out₃`: Array[Int] = new Array[Int](2)
-              `out₃`.update(0, (v: Int))
-              `out₃`.update(1, (v.unary_- : Int))
-              new IntArr(`out₃`, 2)
-            }: FBase): FArray[Int])
-          }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
-            case leaf: IntArr =>
-              val `a₂`: Array[Int] = `leaf₂`.arr
-              val `len₂`: Int = `a₂`.length
-              var `i₂`: Int = 0
-              while (`i₂`.<(`len₂`)) {
-                val `v₃`: Int = `a₂`.apply(`i₂`)
-                val `v₄`: Int = `v₃`.%(2)
-                val `v₅`: Boolean = `v₄`.==(0)
-                if (`v₅`) {
-                  val `v₆`: Int = `v₃`.+(1)
-                  if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                  `out₂`.update(o, `v₆`)
-                  o = o.+(1)
-                } else ()
-                `i₂` = `i₂`.+(1)
-              }
-            case s =>
-              val `len₃`: Int = s.length
-              var `i₃`: Int = 0
-              while (`i₃`.<(`len₃`)) {
-                val `v₇`: Int = FArrayOps.intAt(s, `i₃`)
-                val `v₈`: Int = `v₇`.%(2)
-                val `v₉`: Boolean = `v₈`.==(0)
-                if (`v₉`) {
-                  val `v₁₀`: Int = `v₇`.+(1)
-                  if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                  `out₂`.update(o, `v₁₀`)
-                  o = o.+(1)
-                } else ()
-                `i₃` = `i₃`.+(1)
-              }
+            val `v₃`: Int = v.%(2)
+            val `v₄`: Boolean = `v₃`.==(0)
+            if (`v₄`) {
+              val `v₅`: Int = v.+(1)
+              if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+              `out₂`.update(o, `v₅`)
+              o = o.+(1)
+            } else ()
+            val `v₆`: Int = v.unary_-
+            val `v₇`: Int = `v₆`.%(2)
+            val `v₈`: Boolean = `v₇`.==(0)
+            if (`v₈`) {
+              val `v₉`: Int = v.unary_-
+              val `v₁₀`: Int = `v₉`.+(1)
+              if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+              `out₂`.update(o, `v₁₀`)
+              o = o.+(1)
+            } else ()
+            ()
           } else ()
           i = i.+(1)
         }
       case s =>
-        val `len₄`: Int = `s₂`.length
-        var `i₄`: Int = 0
-        while (`i₄`.<(`len₄`)) {
-          val `v₁₁`: Int = FArrayOps.intAt(`s₂`, `i₄`)
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`)) {
+          val `v₁₁`: Int = FArrayOps.intAt(s, `i₂`)
           val `v₁₂`: Boolean = `v₁₁`.>(0)
           if (`v₁₂`) {
-            val `$proxy₃`: FArray$package {
-              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-            } = FArray$package.$asInstanceOf$[FArray$package {
-              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-            }]
-            val `FArray$package$_this₃`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
-              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-            }]
-            val `b$proxy₃`: Int = `v₁₁`.unary_-
-
-            (({
-              val `r₃`: intRepr.type = intRepr
-              val `out₄`: Array[Int] = new Array[Int](2)
-              `out₄`.update(0, (`v₁₁`: Int))
-              `out₄`.update(1, (`v₁₁`.unary_- : Int))
-              new IntArr(`out₄`, 2)
-            }: FBase): FArray[Int])
-          }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
-            case leaf: IntArr =>
-              val `a₃`: Array[Int] = `leaf₃`.arr
-              val `len₅`: Int = `a₃`.length
-              var `i₅`: Int = 0
-              while (`i₅`.<(`len₅`)) {
-                val `v₁₃`: Int = `a₃`.apply(`i₅`)
-                val `v₁₄`: Int = `v₁₃`.%(2)
-                val `v₁₅`: Boolean = `v₁₄`.==(0)
-                if (`v₁₅`) {
-                  val `v₁₆`: Int = `v₁₃`.+(1)
-                  if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                  `out₂`.update(o, `v₁₆`)
-                  o = o.+(1)
-                } else ()
-                `i₅` = `i₅`.+(1)
-              }
-            case s =>
-              val `len₆`: Int = `s₃`.length
-              var `i₆`: Int = 0
-              while (`i₆`.<(`len₆`)) {
-                val `v₁₇`: Int = FArrayOps.intAt(`s₃`, `i₆`)
-                val `v₁₈`: Int = `v₁₇`.%(2)
-                val `v₁₉`: Boolean = `v₁₈`.==(0)
-                if (`v₁₉`) {
-                  val `v₂₀`: Int = `v₁₇`.+(1)
-                  if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                  `out₂`.update(o, `v₂₀`)
-                  o = o.+(1)
-                } else ()
-                `i₆` = `i₆`.+(1)
-              }
+            val `v₁₃`: Int = `v₁₁`.%(2)
+            val `v₁₄`: Boolean = `v₁₃`.==(0)
+            if (`v₁₄`) {
+              val `v₁₅`: Int = `v₁₁`.+(1)
+              if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+              `out₂`.update(o, `v₁₅`)
+              o = o.+(1)
+            } else ()
+            val `v₁₆`: Int = `v₁₁`.unary_-
+            val `v₁₇`: Int = `v₁₆`.%(2)
+            val `v₁₈`: Boolean = `v₁₇`.==(0)
+            if (`v₁₈`) {
+              val `v₁₉`: Int = `v₁₁`.unary_-
+              val `v₂₀`: Int = `v₁₉`.+(1)
+              if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+              `out₂`.update(o, `v₂₀`)
+              o = o.+(1)
+            } else ()
+            ()
           } else ()
-          `i₄` = `i₄`.+(1)
+          `i₂` = `i₂`.+(1)
         }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(`out₂`.apply(0)) else if (o.==(`out₂`.length)) new IntArr(`out₂`, o) else new IntArr(java.util.Arrays.copyOf(`out₂`, o), o)
@@ -2583,116 +2325,62 @@
         var i: Int = 0
         while (i.<(len).&&(done.unary_!)) {
           val v: Int = a.apply(i)
-          {
-            val `$proxy₂`: FArray$package {
-              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-            } = FArray$package.$asInstanceOf$[FArray$package {
-              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-            }]
-            val `FArray$package$_this₂`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
-              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-            }]
-
-            (({
-              val `r₂`: intRepr.type = intRepr
-              val `out₃`: Array[Int] = new Array[Int](3)
-              `out₃`.update(0, (v: Int))
-              `out₃`.update(1, (v: Int))
-              `out₃`.update(2, (v: Int))
-              new IntArr(`out₃`, 3)
-            }: FBase): FArray[Int])
-          }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
-            case leaf: IntArr =>
-              val `a₂`: Array[Int] = `leaf₂`.arr
-              val `len₂`: Int = `a₂`.length
-              var `i₂`: Int = 0
-              while (`i₂`.<(`len₂`).&&(done.unary_!)) {
-                val `v₂`: Int = `a₂`.apply(`i₂`)
-                val cv: Int = c
-                if (cv.>=(lim)) done = true else {
-                  if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                  `out₂`.update(o, `v₂`)
-                  o = o.+(1)
-                  c = c.+(1)
-                  if (cv.+(1).>=(lim)) done = true else ()
-                }
-                `i₂` = `i₂`.+(1)
-              }
-            case s =>
-              val `len₃`: Int = s.length
-              var `i₃`: Int = 0
-              while (`i₃`.<(`len₃`).&&(done.unary_!)) {
-                val `v₃`: Int = FArrayOps.intAt(s, `i₃`)
-                val `cv₂`: Int = c
-                if (`cv₂`.>=(lim)) done = true else {
-                  if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                  `out₂`.update(o, `v₃`)
-                  o = o.+(1)
-                  c = c.+(1)
-                  if (`cv₂`.+(1).>=(lim)) done = true else ()
-                }
-                `i₃` = `i₃`.+(1)
-              }
+          val cv: Int = c
+          if (cv.>=(lim)) done = true else {
+            if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+            `out₂`.update(o, v)
+            o = o.+(1)
+            c = c.+(1)
+            if (cv.+(1).>=(lim)) done = true else ()
+          }
+          val `cv₂`: Int = c
+          if (`cv₂`.>=(lim)) done = true else {
+            if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+            `out₂`.update(o, v)
+            o = o.+(1)
+            c = c.+(1)
+            if (`cv₂`.+(1).>=(lim)) done = true else ()
+          }
+          val `cv₃`: Int = c
+          if (`cv₃`.>=(lim)) done = true else {
+            if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+            `out₂`.update(o, v)
+            o = o.+(1)
+            c = c.+(1)
+            if (`cv₃`.+(1).>=(lim)) done = true else ()
           }
           i = i.+(1)
         }
       case s =>
-        val `len₄`: Int = `s₂`.length
-        var `i₄`: Int = 0
-        while (`i₄`.<(`len₄`).&&(done.unary_!)) {
-          val `v₄`: Int = FArrayOps.intAt(`s₂`, `i₄`)
-          {
-            val `$proxy₃`: FArray$package {
-              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-            } = FArray$package.$asInstanceOf$[FArray$package {
-              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-            }]
-            val `FArray$package$_this₃`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
-              type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-            }]
-
-            (({
-              val `r₃`: intRepr.type = intRepr
-              val `out₄`: Array[Int] = new Array[Int](3)
-              `out₄`.update(0, (`v₄`: Int))
-              `out₄`.update(1, (`v₄`: Int))
-              `out₄`.update(2, (`v₄`: Int))
-              new IntArr(`out₄`, 3)
-            }: FBase): FArray[Int])
-          }.$asInstanceOf$[FArray[Int]].asInstanceOf[FBase] match {
-            case leaf: IntArr =>
-              val `a₃`: Array[Int] = `leaf₃`.arr
-              val `len₅`: Int = `a₃`.length
-              var `i₅`: Int = 0
-              while (`i₅`.<(`len₅`).&&(done.unary_!)) {
-                val `v₅`: Int = `a₃`.apply(`i₅`)
-                val `cv₃`: Int = c
-                if (`cv₃`.>=(lim)) done = true else {
-                  if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                  `out₂`.update(o, `v₅`)
-                  o = o.+(1)
-                  c = c.+(1)
-                  if (`cv₃`.+(1).>=(lim)) done = true else ()
-                }
-                `i₅` = `i₅`.+(1)
-              }
-            case s =>
-              val `len₆`: Int = `s₃`.length
-              var `i₆`: Int = 0
-              while (`i₆`.<(`len₆`).&&(done.unary_!)) {
-                val `v₆`: Int = FArrayOps.intAt(`s₃`, `i₆`)
-                val `cv₄`: Int = c
-                if (`cv₄`.>=(lim)) done = true else {
-                  if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                  `out₂`.update(o, `v₆`)
-                  o = o.+(1)
-                  c = c.+(1)
-                  if (`cv₄`.+(1).>=(lim)) done = true else ()
-                }
-                `i₆` = `i₆`.+(1)
-              }
+        val `len₂`: Int = s.length
+        var `i₂`: Int = 0
+        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
+          val `v₂`: Int = FArrayOps.intAt(s, `i₂`)
+          val `cv₄`: Int = c
+          if (`cv₄`.>=(lim)) done = true else {
+            if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+            `out₂`.update(o, `v₂`)
+            o = o.+(1)
+            c = c.+(1)
+            if (`cv₄`.+(1).>=(lim)) done = true else ()
           }
-          `i₄` = `i₄`.+(1)
+          val `cv₅`: Int = c
+          if (`cv₅`.>=(lim)) done = true else {
+            if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+            `out₂`.update(o, `v₂`)
+            o = o.+(1)
+            c = c.+(1)
+            if (`cv₅`.+(1).>=(lim)) done = true else ()
+          }
+          val `cv₆`: Int = c
+          if (`cv₆`.>=(lim)) done = true else {
+            if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+            `out₂`.update(o, `v₂`)
+            o = o.+(1)
+            c = c.+(1)
+            if (`cv₆`.+(1).>=(lim)) done = true else ()
+          }
+          `i₂` = `i₂`.+(1)
         }
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(`out₂`.apply(0)) else if (o.==(`out₂`.length)) new IntArr(`out₂`, o) else new IntArr(java.util.Arrays.copyOf(`out₂`, o), o)

--- a/tests/src/scala/farray/NewKindsSmoke.scala
+++ b/tests/src/scala/farray/NewKindsSmoke.scala
@@ -1,0 +1,60 @@
+package farray
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+class NewKindsSmoke {
+  @Test def floatKind(): Unit = {
+    val xs = FArray(1.0f, 2.5f, 3.0f)
+    val ls = List(1.0f, 2.5f, 3.0f)
+    assertEquals(ls.map(_ * 2), xs.map(_ * 2).toList)
+    assertEquals(ls.foldLeft(0.0f)(_ + _), xs.foldLeft(0.0f)(_ + _), 0.0f)
+    assertEquals(ls.filter(_ > 1.5f), xs.filter(_ > 1.5f).toList)
+    assertEquals(ls.sum, xs.sum, 0.0f)
+    assertEquals(ls.reverse, xs.reverse.toList)
+    assertEquals(ls.hashCode, xs.toList.hashCode)
+  }
+  @Test def shortKind(): Unit = {
+    val xs = FArray(1.toShort, 2.toShort, 3.toShort)
+    val ls = List(1.toShort, 2.toShort, 3.toShort)
+    assertEquals(ls.map(s => (s + 1).toShort), xs.map(s => (s + 1).toShort).toList)
+    assertEquals(ls.foldLeft(0)(_ + _), xs.foldLeft(0)(_ + _))
+    assertEquals(ls.sum, xs.sum)
+    assertEquals(ls.toList.hashCode, xs.toList.hashCode)
+  }
+  @Test def byteKind(): Unit = {
+    val xs = FArray(1.toByte, 2.toByte, 3.toByte)
+    val ls = List(1.toByte, 2.toByte, 3.toByte)
+    assertEquals(ls.map(b => (b * 2).toByte), xs.map(b => (b * 2).toByte).toList)
+    assertEquals(ls.sum, xs.sum)
+    assertEquals(ls.foldLeft(0)(_ + _), xs.foldLeft(0)(_ + _))
+    assertEquals(ls.toList.hashCode, xs.toList.hashCode)
+  }
+  @Test def charKind(): Unit = {
+    val xs = FArray('a', 'b', 'c')
+    val ls = List('a', 'b', 'c')
+    assertEquals(ls.map(_.toUpper), xs.map(_.toUpper).toList)
+    assertEquals(ls.foldLeft(0)(_ + _.toInt), xs.foldLeft(0)(_ + _.toInt))
+    assertEquals(ls.filter(_ != 'b'), xs.filter(_ != 'b').toList)
+    assertEquals(ls.toList.hashCode, xs.toList.hashCode)
+  }
+  @Test def booleanKind(): Unit = {
+    val xs = FArray(true, false, true, true)
+    val ls = List(true, false, true, true)
+    assertEquals(ls.map(!_), xs.map(!_).toList)
+    assertEquals(ls.count(identity), xs.count(identity))
+    assertEquals(ls.filter(identity), xs.filter(identity).toList)
+    assertEquals(ls.foldLeft(0)((a, b) => a + (if (b) 1 else 0)), xs.foldLeft(0)((a, b) => a + (if (b) 1 else 0)))
+    assertEquals(ls.toList.hashCode, xs.toList.hashCode)
+  }
+  @Test def structuralAcrossKinds(): Unit = {
+    // exercise tree nodes (concat, take, drop, reverse, updated) for a new kind
+    val xs = FArray.tabulate(20)(i => i.toFloat)
+    val ls = List.tabulate(20)(i => i.toFloat)
+    assertEquals((ls ++ ls).map(_ + 1), (xs ++ xs).map(_ + 1).toList)
+    assertEquals(ls.drop(3).take(5), xs.drop(3).take(5).toList)
+    assertEquals(ls.reverse, xs.reverse.toList)
+    assertEquals(ls.updated(2, 99.0f), xs.updated(2, 99.0f).toList)
+    assertEquals((ls ++ ls).reverse.hashCode, (xs ++ xs).reverse.toList.hashCode)
+  }
+
+}

--- a/tests/src/scala/farray/NewKindsSmoke.scala
+++ b/tests/src/scala/farray/NewKindsSmoke.scala
@@ -57,4 +57,27 @@ class NewKindsSmoke {
     assertEquals((ls ++ ls).reverse.hashCode, (xs ++ xs).reverse.toList.hashCode)
   }
 
+
+  @Test def fuseFloatKind(): Unit = {
+    val xf = FArray.tabulate(12)(i => i.toFloat)
+    val lf = List.tabulate(12)(i => i.toFloat)
+    assertEquals(
+      lf.flatMap(x => List(x, x + 1.0f)).filter(_ % 2.0f == 0.0f).map(_ * 2.0f).foldLeft(0.0f)(_ + _),
+      xf.fuse.flatMap(x => FArray(x, x + 1.0f)).filter(_ % 2.0f == 0.0f).map(_ * 2.0f).foldLeft(0.0f)(_ + _), 0.001f)
+    assertEquals(lf.map(_ + 1.0f), xf.fuse.map(_ + 1.0f).run.toList)
+  }
+  @Test def fuseCharKind(): Unit = {
+    val xc = FArray('a', 'b', 'c', 'd')
+    val lc = List('a', 'b', 'c', 'd')
+    assertEquals(
+      lc.flatMap(c => List(c, c.toUpper)).map(_.toInt).sum,
+      xc.fuse.flatMap(c => FArray(c, c.toUpper)).map(_.toInt).foldLeft(0)(_ + _))
+    assertEquals(lc.filter(_ != 'b').map(_.toUpper), xc.fuse.filter(_ != 'b').map(_.toUpper).run.toList)
+  }
+  @Test def fuseBooleanKind(): Unit = {
+    val xb = FArray(true, false, true, true, false)
+    val lb = List(true, false, true, true, false)
+    assertEquals(lb.count(identity), xb.fuse.filter(identity).count)
+    assertEquals(lb.map(!_), xb.fuse.map(!_).run.toList)
+  }
 }

--- a/tests/src/scala/farray/NewKindsSmoke.scala
+++ b/tests/src/scala/farray/NewKindsSmoke.scala
@@ -57,21 +57,20 @@ class NewKindsSmoke {
     assertEquals((ls ++ ls).reverse.hashCode, (xs ++ xs).reverse.toList.hashCode)
   }
 
-
   @Test def fuseFloatKind(): Unit = {
     val xf = FArray.tabulate(12)(i => i.toFloat)
     val lf = List.tabulate(12)(i => i.toFloat)
     assertEquals(
       lf.flatMap(x => List(x, x + 1.0f)).filter(_ % 2.0f == 0.0f).map(_ * 2.0f).foldLeft(0.0f)(_ + _),
-      xf.fuse.flatMap(x => FArray(x, x + 1.0f)).filter(_ % 2.0f == 0.0f).map(_ * 2.0f).foldLeft(0.0f)(_ + _), 0.001f)
+      xf.fuse.flatMap(x => FArray(x, x + 1.0f)).filter(_ % 2.0f == 0.0f).map(_ * 2.0f).foldLeft(0.0f)(_ + _),
+      0.001f
+    )
     assertEquals(lf.map(_ + 1.0f), xf.fuse.map(_ + 1.0f).run.toList)
   }
   @Test def fuseCharKind(): Unit = {
     val xc = FArray('a', 'b', 'c', 'd')
     val lc = List('a', 'b', 'c', 'd')
-    assertEquals(
-      lc.flatMap(c => List(c, c.toUpper)).map(_.toInt).sum,
-      xc.fuse.flatMap(c => FArray(c, c.toUpper)).map(_.toInt).foldLeft(0)(_ + _))
+    assertEquals(lc.flatMap(c => List(c, c.toUpper)).map(_.toInt).sum, xc.fuse.flatMap(c => FArray(c, c.toUpper)).map(_.toInt).foldLeft(0)(_ + _))
     assertEquals(lc.filter(_ != 'b').map(_.toUpper), xc.fuse.filter(_ != 'b').map(_.toUpper).run.toList)
   }
   @Test def fuseBooleanKind(): Unit = {


### PR DESCRIPTION
This branch started as a rigorous investigation into one hypothesis — *do the standard immutable collections quietly fall off a cliff in realistic, method-heavy code?* — and it kept paying out. The answer turned out to be a clear **yes, and FArray doesn't.** Along the way it produced unboxed Ref+prim folds, a zero-allocation fused `flatMap`, specialization over *every* JVM primitive, and a fresh per-primitive benchmark suite to prove it.

## The hypothesis (confirmed, with receipts)

A competitor's unboxed `map`/`fold` isn't free — it depends on the JIT inlining its **shared** `Array.foldLeft` / `List.map` at each call site so the lambda devirtualizes to the specialized unboxed form. That shared method's **signature is generic** (`foldLeft(Object, Function2): Object`), so the moment it *isn't* inlined — which happens as soon as the enclosing method gets big, or the program throws a few distinct lambdas at it — every element **boxes**. FArray's unboxing lives in the *method signature itself* (`reduceLeafFwdIntInt(FBase, int, IntToIntFold): int` + an unboxed SAM), so it never hinges on a JIT inlining decision.

Proven three ways: at the bytecode level (`javap`), via the deterministic `-prof gc` B/op tell, and a flag-flip causation test — on both a pure HotSpot C2 JVM and GraalVM.

## What landed

1. **Unboxed primitive accumulator over reference elements** — `xs.foldLeft(0)((n, s) => n + s.length)`, the single most common reference fold, used to box the Int accumulator on every element. Now it doesn't. *(This one also landed independently on `main`; rebased away.)*
2. **Zero-allocation fused `flatMap`** — diagnosed via escape-analysis byte accounting: `flatMap(x => FArray(x, x+1))` was leaking one small array per element (the JIT scalar-replaces the wrapper but not the backing array — a variable-indexed array isn't scalar-replaceable on HotSpot). Fixed with an inline leaf fast-path + a literal-`FArray` splat that emits `body(e0); body(e1)` directly: no array, no wrapper, **0 alloc**. Extended to the Ref leaf too.
3. **Specialization over every JVM primitive** — ops, *eager and fused*, now specialize over all 8: Int, Long, Double, **Float, Short, Byte, Char, Boolean** (was Int/Long/Double/Ref). Hunted down every spot that hardcoded the old set (`jelem`, `Hashing.java`, the `fromBoxed` family, `Tuple2` specialization, sum/product/Numeric…).
4. **A comprehensive per-primitive benchmark suite** — one long mixed pipeline per kind, all 6 collections + a fused variant, apples-to-apples.

## The scores 🚀

### What's measured

One **long, realistic pipeline per primitive type**, run identically across all six collections (and a fused FArray variant on top). Each pipeline is a 14-stage chain:

```
flatMap · filter · map · flatMap · filter · map · zip · map · zipWithIndex · filter · map · flatMap · filter · foldLeft
```

This is deliberately *not* a microbenchmark. Every stage exists on every collection (so it's apples-to-apples), every lambda is distinct (so nothing can be CSE'd away), and the chain is long enough that two real costs show up at once:

1. **Per-element boxing** of the primitive payload — the thing the whole "big-method cliff" hypothesis is about.
2. **Intermediate-collection allocation** — every eager stage builds a fresh collection; `.fuse` builds *none*.

Inputs are 10,000 elements. Competitors: `List`, `Vector`, `IArray`, `fs2.Chunk`, `zio.Chunk`. `@Param` sizes, `-prof gc` for the allocation numbers, two forks. The benchmark sources are in this PR (`{Kind}AllOpsBench.scala`) so anyone can re-run them.


### The benchmark code

The eight `{Kind}AllOpsBench.scala` files share one shape: the **same 14-stage chain written once per collection** (`list` / `vector` / `iarray` / `farray` / `fs2chunk` / `ziochunk`) plus a 7th `farrayFused` method. Every lambda is distinct so the JIT can't CSE them — that's what drives the competitors' shared `map`/`fold` call sites megamorphic and triggers the boxing cliff. Inputs come from a `{Kind}Inputs` trait (`Int` reuses the existing `IntInputs`).

<details>
<summary><b>IntAllOpsBench.scala</b> — the template (FArray + fused shown; the 5 competitors are the byte-for-byte same chain)</summary>

```scala
class IntAllOpsBench extends IntInputs {

  @Benchmark def farray(): Int = farrayInput
    .flatMap(x => FArray(x, x + 1))
    .filter(_ % 3 != 0)
    .map(_ * 2)
    .flatMap(x => FArray(x, x ^ 5))
    .filter(_ % 2 == 0)
    .map(_ - 7)
    .zip(farrayInput.map(_ + 100))
    .map((a, b) => a + b)
    .zipWithIndex
    .filter((v, i) => (v + i) % 4 != 0)
    .map((v, i) => v - i)
    .flatMap(x => FArray(x, x + 3))
    .filter(_ > 0)
    .foldLeft(0)((acc, x) => acc + x)

  // def list / vector / iarray / fs2chunk / ziochunk — identical chain over each collection's own ctor

  @Benchmark def farrayFused(): Int = {
    val zipSrc = farrayInput.map(_ + 100)   // hoisted: the fuse macro reads zip's arg off the AST
    farrayInput.fuse
      .flatMap(x => FArray(x, x + 1))
      .filter(_ % 3 != 0)
      .map(_ * 2)
      .flatMap(x => FArray(x, x ^ 5))
      .filter(_ % 2 == 0)
      .map(_ - 7)
      .zip(zipSrc)
      .map((a, b) => a + b)
      .zipWithIndex
      .filter((v, i) => (v + i) % 4 != 0)
      .map((v, i) => v - i)
      .flatMap(x => FArray(x, x + 3))
      .filter(_ > 0)
      .foldLeft(0)((acc, x) => acc + x)
  }
}
```
</details>

The per-kind lambdas adapt to stay valid and meaningful for each element type (the pipeline *shape* never changes). Two of the non-obvious ones:

<details>
<summary><b>CharAllOpsBench / BooleanAllOpsBench</b> — no <code>+</code>/<code>*</code> on Char/Boolean results</summary>

```scala
// Char: arithmetic narrows back via .toChar; folds to Int via .toInt
@Benchmark def farray(): Int = farrayInput
  .flatMap(c => FArray(c, c.toUpper)).filter(_ != 'b').map(c => (c + 1).toChar)
  .flatMap(c => FArray(c, c.toLower)).filter(_ != 'z').map(c => (c ^ 2).toChar)
  .zip(farrayInput.map(c => (c + 1).toChar)).map((a, b) => (a + b).toChar)
  .zipWithIndex.filter((v, i) => i % 4 != 0).map((v, i) => (v + i).toChar)
  .flatMap(c => FArray(c, c.toUpper)).filter(_ != 'q')
  .foldLeft(0)((acc, x) => acc + x.toInt)

// Boolean: pure logic (!, &, |, ^); fold counts the trues
@Benchmark def farray(): Int = farrayInput
  .flatMap(b => FArray(b, !b)).filter(identity).map(!_)
  .flatMap(b => FArray(b, b & true)).filter(b => b | true).map(!_)
  .zip(farrayInput.map(!_)).map((a, b) => a ^ b)
  .zipWithIndex.filter((v, i) => i % 4 != 0).map((v, i) => v ^ (i % 2 == 0))
  .flatMap(b => FArray(b, !b)).filter(identity)
  .foldLeft(0)((acc, x) => acc + (if (x) 1 else 0))
```

`Long`/`Double`/`Float` mirror `Int` with `1L`/`1.0`/`1.0f` literals (and fold to their own type); `Short`/`Byte` mirror `Int` but narrow each arithmetic result with `.toShort`/`.toByte` (Scala widens `short + short` to `Int`).
</details>

### How to read the tables

- **× vs best rival** = FArray's throughput divided by *the fastest of all five competitors* for that kind. It's the kindest possible comparison for them — FArray isn't being measured against the slowest, but against whichever one happens to win that row.
- **eager FArray** is the ordinary API (`farrayInput.flatMap(...).filter(...)...`) — a drop-in replacement, no fusion.
- **FArray.fuse** runs the *same logical pipeline* in one pass with no intermediate collections.
- **allocation (bytes/op)** = total heap allocated per single run of the pipeline, straight from JMH's `gc.alloc.rate.norm`. Lower is better. "fuse allocates N× less" compares FArray.fuse against the *lowest-allocating competitor* for that kind.

---

### GraalVM CE 25 (the project's JVM) — throughput (ops/s, higher is better)

| element | IArray | eager FArray | × vs best rival | **FArray.fuse** | × vs best rival |
|---|--:|--:|--:|--:|--:|
| Int | 1,639 | 4,084 | 2.5× | **66,694** | **41×** |
| Long | 1,538 | 3,754 | 2.4× | **67,916** | **44×** |
| Double | 1,387 | 3,566 | 2.6× | **91,292** | **66×** |
| Float | 1,516 | 2,824 | 1.9× | **26,839** | **18×** |
| Short | 1,641 | 2,954 | 1.8× | **14,270** | **9×** |
| Byte | 2,645 | 3,784 | 1.4× | **14,719** | **6×** |
| Char | 1,954 | 3,367 | 1.7× | **16,236** | **8×** |
| Boolean | 2,756 | 4,790 | 1.7× | **24,452** | **9×** |

### GraalVM CE 25 (the project's JVM) — allocation per run (bytes/op, lower is better)

| element | IArray | best competitor | eager FArray | **FArray.fuse** | fuse allocates |
|---|--:|--:|--:|--:|--:|
| Int | 5.2 MB | 5.2 MB (IArray) | 2.4 MB | **40 KB** | **130× less** |
| Long | 8.0 MB | 7.0 MB (Vector) | 3.6 MB | **80 KB** | **87× less** |
| Double | 9.8 MB | 8.5 MB (Vector) | 4.1 MB | **80 KB** | **106× less** |
| Float | 6.2 MB | 6.2 MB (IArray) | 3.2 MB | **400 KB** | **15× less** |
| Short | 3.7 MB | 3.7 MB (IArray) | 2.5 MB | **680 KB** | **5× less** |
| Byte | 2.2 MB | 2.2 MB (IArray) | 1.7 MB | **611 KB** | **4× less** |
| Char | 3.9 MB | 3.9 MB (IArray) | 2.2 MB | **387 KB** | **10× less** |
| Boolean | 2.3 MB | 2.3 MB (IArray) | 1.6 MB | **430 KB** | **5× less** |

The allocation table is where the story is clearest. On Int, the best any competitor manages is **5.2 MB** allocated per run — that's intermediate collections plus a boxed `Integer` for essentially every element. Eager FArray already halves it (2.4 MB: unboxed leaves, but still one fresh collection per stage). **FArray.fuse drops it to 40 KB** — three orders of magnitude less — because there are no intermediate collections and no boxing at all; it's a single unboxed loop. Throughput tracks allocation closely: less garbage, less GC, more work done.

---

### HotSpot C2 (Temurin 25) — throughput (ops/s, higher is better)

| element | IArray | eager FArray | × vs best rival | **FArray.fuse** | × vs best rival |
|---|--:|--:|--:|--:|--:|
| Int | 950 | 5,928 | 5.3× | **30,050** | **27×** |
| Long | 902 | 8,542 | 7.9× | **31,903** | **29×** |
| Double | 707 | 6,498 | 7.9× | **26,079** | **32×** |
| Float | 740 | 5,313 | 6.2× | **15,509** | **18×** |
| Short | 984 | 3,783 | 3.7× | **15,081** | **15×** |
| Byte | 1,693 | 6,155 | 3.6× | **16,227** | **10×** |
| Char | 1,171 | 4,523 | 3.9× | **14,608** | **12×** |
| Boolean | 1,806 | 8,202 | 4.5× | **28,940** | **16×** |

### HotSpot C2 (Temurin 25) — allocation per run (bytes/op, lower is better)

| element | IArray | best competitor | eager FArray | **FArray.fuse** | fuse allocates |
|---|--:|--:|--:|--:|--:|
| Int | 8.1 MB | 5.2 MB (Vector) | 1.6 MB | **40 KB** | **130× less** |
| Long | 12.3 MB | 6.3 MB (Vector) | 2.6 MB | **80 KB** | **79× less** |
| Double | 15.3 MB | 8.0 MB (Vector) | 2.9 MB | **80 KB** | **99× less** |
| Float | 9.9 MB | 6.2 MB (Vector) | 2.3 MB | **400 KB** | **16× less** |
| Short | 7.1 MB | 5.2 MB (Vector) | 2.0 MB | **680 KB** | **8× less** |
| Byte | 2.7 MB | 2.7 MB (IArray) | 1.2 MB | **611 KB** | **4× less** |
| Char | 4.7 MB | 4.7 MB (IArray) | 1.5 MB | **387 KB** | **12× less** |
| Boolean | 2.5 MB | 2.5 MB (IArray) | 954 KB | **250 KB** | **10× less** |

**HotSpot C2 is where the hypothesis bites hardest.** C2's escape analysis and inlining are less aggressive than GraalVM's, so the competitors' shared `map`/`fold` falls back to the boxed generic path much more readily in a method this size — and **eager FArray pulls further ahead: 3.6×–7.9×** over the best rival, versus 1.4×–2.6× on GraalVM. Fused stays 10×–32× across the board. The effect isn't a GraalVM quirk; it's worse on the JVM most people actually run.

### The honest footnotes

- **Float / Short / Byte get smaller wins** (and allocate more when fused — note their 400–680 KB vs Int's 40 KB). That's the `zip`/`zipWithIndex` stages: Scala's stdlib only `@specialize`s `Tuple2` over Int/Long/Double/Char/Boolean, so a `(Float, Int)` pair *boxes the Float*. Nothing FArray can fix — it's a library limitation — but everything *outside* the tuple stays unboxed, which is why they still win 6×–18×.
- The numbers above are a single representative size (10k). FArray's lead is largest in the 100–10k range; at 100k it narrows somewhat as everything becomes memory-bandwidth-bound, but FArray never loses a kind on either JVM.

## Correctness & method

367 tests green, including a new `NewKindsSmoke` that exercises every new primitive across eager **and** fused vs `List`, plus the existing `FExhaustiveTest` over every node shape and `FListTest` parity. Cross-impl parity of the benchmark pipelines themselves was verified separately.

The project runs GraalVM CE 25 (JVMCI JIT), so a pure HotSpot C2 (`temurin:25`) was used to validate the hypothesis on the JVM it's literally about; every number above is reported on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

