### PR TITLE
fuse: ONE element loop — dedupe the peeled-leaf arm, fix live slack-leaf bug

### DIFF
--- a/benchmarks/src/scala/farray/FuseSourceShapeBench.scala
+++ b/benchmarks/src/scala/farray/FuseSourceShapeBench.scala
@@ -1,0 +1,63 @@
+package farray
+
+import org.openjdk.jmh.annotations.*
+import java.util.concurrent.TimeUnit
+
+/** Fuse over each source SHAPE the element loop dispatches on: flat leaf (the fast path), a Concat tree (the fallback arm), and a One node (alloc-sensitive
+  * tiny case). Gates the elementLoop dedup redesign: leaf entries must tie the old two-arm loop exactly, tree/One entries measure the fallback strategy
+  * (per-element `<kind>At` vs null-unswitched read vs materialize-once).
+  */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 4, time = 400, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 6, time = 400, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(1)
+class FuseSourceShapeBench:
+  @Param(Array("1000", "100000"))
+  var size: Int = 1000
+
+  var leaf: FArray[Int] = _
+  var tree: FArray[Int] = _ // ++ of 8 leaves — stays a Concat node
+  var one: FArray[Int] = _
+  var last: Int = _
+
+  @Setup
+  def setup(): Unit =
+    leaf = FArray.tabulate(size)(i => i)
+    val seg = size / 8
+    var t = FArray.tabulate(seg)(i => i)
+    var k = 1
+    while k < 8 do
+      val base = k * seg
+      t = t ++ FArray.tabulate(if k == 7 then size - base else seg)(i => base + i)
+      k += 1
+    tree = t
+    one = FArray(42)
+    last = size - 1
+    tinyTree = FArray(1, 2) ++ FArray(3, 4)
+
+  // control: flat-leaf source — any redesign must tie the old leaf arm exactly
+  @Benchmark def leafMapFilterRun(): FArray[Int] = leaf.fuse.map(_ + 1).filter(_ % 2 == 0).map(_ * 2).run
+  @Benchmark def leafFold(): Int = leaf.fuse.foldLeft(0)(_ + _)
+
+  // tree source: the fallback arm
+  @Benchmark def treeMapFilterRun(): FArray[Int] = tree.fuse.map(_ + 1).filter(_ % 2 == 0).map(_ * 2).run
+  @Benchmark def treeFold(): Int = tree.fuse.foldLeft(0)(_ + _)
+  @Benchmark def treeExistsEarly(): Boolean = tree.fuse.exists(_ == 0)
+  @Benchmark def treeExistsLate(): Boolean = tree.fuse.exists(_ == last)
+
+  // One-node source: any per-call allocation shows up here
+  @Benchmark def oneMapRun(): FArray[Int] = one.fuse.map(_ + 1).run
+  @Benchmark def oneFold(): Int = one.fuse.foldLeft(0)(_ + _)
+
+  // general (non-literal) flatMap inners — these DO go through elementLoop, unlike the literal
+  // FArray(a, b) inners in FusionBench/AllOps benches, which the macro splats without a loop.
+  // Fresh leaf per element: the EA/scalar-replacement-sensitive case the leaf fast-path exists for.
+  @Benchmark def flatMapFreshLeafInner(): Int =
+    leaf.fuse.flatMap(x => FArray.tabulate(2)(i => x + i)).foldLeft(0)(_ + _)
+  // Shared tiny tree per element: the fallback arm inside a hot nested loop (per-element re-materialize
+  // would be an alloc storm here; per-element <kind>At is a cheap shallow walk).
+  var tinyTree: FArray[Int] = _
+  @Benchmark def flatMapTreeInner(): Int =
+    leaf.fuse.flatMap(_ => tinyTree).foldLeft(0)(_ + _)

--- a/farray/src/scala/farray/FuseMacro.scala
+++ b/farray/src/scala/farray/FuseMacro.scala
@@ -1069,7 +1069,7 @@ object FuseMacro:
           case None =>
             // general flatMap: open a nested loop over f(cur); everything downstream runs inside it.
             val inner: Expr[FBase] = '{ ${ innerBody.asExpr }.asInstanceOf[FBase] }
-            loopOver(inner, kindOf(bTpe), bTpe, rest, ctx).asTerm
+            loopOver(inner, kindOf(bTpe), bTpe, rest, ctx, outer = false).asTerm
       case (CollectS(pf, bTpe), _) :: rest =>
         // inline the PartialFunction's match into the loop: each real case continues downstream, the synthetic
         // `case _ => default(x)` fallthrough becomes a skip. So collect is filter+map+match fused, no PF object.
@@ -1217,121 +1217,117 @@ object FuseMacro:
     // The shared INNER element loop over ONE realized chunk `s` (an `FBase` leaf/tree). Both the in-memory path
     // (one chunk = the whole FArray) and the streaming chunk-driver (many chunks) emit this verbatim — only the
     // SOURCE of `s` differs. `cond` already folds in `done`, so a satisfied short-circuit stops mid-chunk.
-    def elementLoop(src: Expr[FBase], k: Kind, elemTpe: TypeRepr, ss: List[(Stage, Int)], ctx: Ctx): Expr[Unit] =
+    def elementLoop(src: Expr[FBase], k: Kind, elemTpe: TypeRepr, ss: List[(Stage, Int)], ctx: Ctx, outer: Boolean): Expr[Unit] =
       def cond(len: Expr[Int], i: Expr[Int]): Expr[Boolean] = ctx.done match
         case Some(d) => '{ $i < $len && ! ${ d.read } }
         case None    => '{ $i < $len }
       def perElem(read: Term): Expr[Unit] =
         letBind(read)(x => buildBody(ss, x, ctx)).asExprOf[Unit]
-      // A `${K}Arr` LEAF fast-path peeled INLINE ahead of the `${kind}At` fallback. Why it matters: a `flatMap`
-      // inner builds a fresh small `${K}Arr` PER ELEMENT; reading it back through `${kind}At` (an FBase-typed
-      // megamorphic call) makes the freshly-allocated array ESCAPE, so the JIT can't scalar-replace it — on
-      // HotSpot C2 (weaker escape analysis than GraalVM) this turns a no-alloc fused pass into a per-element
-      // allocation and craters it (measured ~13x slower than eager). Reading `leaf.arr(i)` from a CONCRETE
-      // `${K}Arr` is monomorphic and INLINE (no call boundary) so EA proves the array stays local → scalar-
-      // replaced, no alloc, on both JVMs. The `${kind}At` arm still serves genuine tree sources (Concat/Slice/…).
-      // NOTE (measured, do NOT "simplify" back): routing this through the SHARED `foreachLeaf${K}`/`scFwdLeaf${K}`
-      // driver (push each element through a `${K}Consumer`/`${K}Pred` SAM) is 1.7-2.8x SLOWER here — passing the
-      // fresh inner array INTO a shared method is itself an escape boundary that defeats scalar replacement on
-      // BOTH C2 and GraalVM. The inline leaf-match is the point. Loop bound is `a.length` (the backing array's),
-      // NOT leaf.length, so the JIT drops the per-element bounds check.
-      elemTpe.asType match
-        case '[se] =>
-          k match
-            case Kind.KInt =>
-              '{
-                $src match
-                  case leaf: IntArr =>
-                    val a = leaf.arr; val len = a.length; var i = 0
-                    while ${ cond('len, 'i) } do { ${ perElem('{ a(i) }.asTerm) }; i += 1 }
-                  case s =>
-                    val len = s.length; var i = 0
-                    while ${ cond('len, 'i) } do { ${ perElem('{ FArrayOps.intAt(s, i) }.asTerm) }; i += 1 }
-              }
-            case Kind.KLong =>
-              '{
-                $src match
-                  case leaf: LongArr =>
-                    val a = leaf.arr; val len = a.length; var i = 0
-                    while ${ cond('len, 'i) } do { ${ perElem('{ a(i) }.asTerm) }; i += 1 }
-                  case s =>
-                    val len = s.length; var i = 0
-                    while ${ cond('len, 'i) } do { ${ perElem('{ FArrayOps.longAt(s, i) }.asTerm) }; i += 1 }
-              }
-            case Kind.KDouble =>
-              '{
-                $src match
-                  case leaf: DoubleArr =>
-                    val a = leaf.arr; val len = a.length; var i = 0
-                    while ${ cond('len, 'i) } do { ${ perElem('{ a(i) }.asTerm) }; i += 1 }
-                  case s =>
-                    val len = s.length; var i = 0
-                    while ${ cond('len, 'i) } do { ${ perElem('{ FArrayOps.doubleAt(s, i) }.asTerm) }; i += 1 }
-              }
-            case Kind.KFloat =>
-              '{
-                $src match
-                  case leaf: FloatArr =>
-                    val a = leaf.arr; val len = a.length; var i = 0
-                    while ${ cond('len, 'i) } do { ${ perElem('{ a(i) }.asTerm) }; i += 1 }
-                  case s =>
-                    val len = s.length; var i = 0
-                    while ${ cond('len, 'i) } do { ${ perElem('{ FArrayOps.floatAt(s, i) }.asTerm) }; i += 1 }
-              }
-            case Kind.KShort =>
-              '{
-                $src match
-                  case leaf: ShortArr =>
-                    val a = leaf.arr; val len = a.length; var i = 0
-                    while ${ cond('len, 'i) } do { ${ perElem('{ a(i) }.asTerm) }; i += 1 }
-                  case s =>
-                    val len = s.length; var i = 0
-                    while ${ cond('len, 'i) } do { ${ perElem('{ FArrayOps.shortAt(s, i) }.asTerm) }; i += 1 }
-              }
-            case Kind.KByte =>
-              '{
-                $src match
-                  case leaf: ByteArr =>
-                    val a = leaf.arr; val len = a.length; var i = 0
-                    while ${ cond('len, 'i) } do { ${ perElem('{ a(i) }.asTerm) }; i += 1 }
-                  case s =>
-                    val len = s.length; var i = 0
-                    while ${ cond('len, 'i) } do { ${ perElem('{ FArrayOps.byteAt(s, i) }.asTerm) }; i += 1 }
-              }
-            case Kind.KChar =>
-              '{
-                $src match
-                  case leaf: CharArr =>
-                    val a = leaf.arr; val len = a.length; var i = 0
-                    while ${ cond('len, 'i) } do { ${ perElem('{ a(i) }.asTerm) }; i += 1 }
-                  case s =>
-                    val len = s.length; var i = 0
-                    while ${ cond('len, 'i) } do { ${ perElem('{ FArrayOps.charAt(s, i) }.asTerm) }; i += 1 }
-              }
-            case Kind.KBoolean =>
-              '{
-                $src match
-                  case leaf: BooleanArr =>
-                    val a = leaf.arr; val len = a.length; var i = 0
-                    while ${ cond('len, 'i) } do { ${ perElem('{ a(i) }.asTerm) }; i += 1 }
-                  case s =>
-                    val len = s.length; var i = 0
-                    while ${ cond('len, 'i) } do { ${ perElem('{ FArrayOps.booleanAt(s, i) }.asTerm) }; i += 1 }
-              }
-            case Kind.KRef =>
-              '{
-                $src match
-                  case leaf: RefArr =>
-                    val a = leaf.arr; val len = a.length; var i = 0
-                    while ${ cond('len, 'i) } do { ${ perElem('{ a(i).asInstanceOf[se] }.asTerm) }; i += 1 }
-                  case s =>
-                    val len = s.length; var i = 0
-                    while ${ cond('len, 'i) } do { ${ perElem('{ FArrayOps.refAt(s, i).asInstanceOf[se] }.asTerm) }; i += 1 }
-              }
+      // ONE loop, emitted once — the fused body is NOT duplicated per source shape (a long fused body twice per
+      // loop was real bytecode bloat, and the old peeled leaf arm looped to `a.length`, reading slack slots —
+      // `${K}Arr` leaves carry slack: groupBy values wrap the growable buffer, arr.length > length).
+      //
+      // The element read is `if (a ne null) a(i) else <kind>At(s, i)`, with `a` bound ONCE before the loop:
+      //   • `${K}Arr` leaf → `leaf.arr`. For a fresh flatMap-inner leaf the JIT knows the exact type, folds the
+      //     match AND the null check, and EA/scalar replacement works exactly like the old peeled leaf arm.
+      //     (What breaks EA — measured, do NOT reintroduce — is pushing elements through a shared
+      //     `${K}Consumer`/driver call: 1.7-2.8x slower. A branch on a loop-invariant LOCAL is not a call
+      //     boundary: the JIT folds it by type speculation or unswitches the loop.)
+      //   • other node on an OUTER loop with NO done-flag → `materialize<K>(s)` once: the sink traverses
+      //     everything anyway, and a flat loop over the copy beats per-element `<kind>At` tree walks ~17x @100k
+      //     (FuseSourceShapeBench.treeFold). Gated on length >= 64 so One/tiny nodes don't pay the alloc.
+      //   • other node otherwise → null, i.e. per-element `<kind>At`: short-circuit sinks must not pre-flatten
+      //     (treeExistsEarly never traverses at all), and a shared flatMap-inner tree must not re-materialize
+      //     per outer element (flatMapTreeInner would become an alloc storm). Known cost: on C2 a very short
+      //     fallback loop pays the per-element null-check — fused flatMap over a shared TINY tree inner is
+      //     0.80x of the old dedicated intAt arm (C2 only; GraalVM ties). Materializing tiny inners instead
+      //     was MEASURED WORSE (828 vs 1015 ops/s, 15MB/op): the per-outer-element copy costs more than the
+      //     branch. Accepted — the shape is pathological (eager flatMap's ${K}FlatMap node serves it).
+      //
+      // Loop bound is `s.length` — the LOGICAL length, never `arr.length` (slack). Per the reduceLeaf note in
+      // GenCores, a single-bound loop on the logical length ties `a.length` exactly (loop predication); the
+      // compound `i < a.length && i < len` form is what kills vectorization — never that.
+      val mat = outer && ctx.done.isEmpty
+      def skeleton[Arr <: AnyRef](arrOf: Expr[FBase] => Expr[Arr], read: (Expr[Arr], Expr[Int]) => Term)(using Type[Arr]): Expr[Unit] =
+        elemTpe.asType match
+          case '[se] =>
+            '{
+              val s: FBase = $src
+              val a: Arr = ${ arrOf('s) }
+              val len: Int = s.length
+              var i: Int = 0
+              while ${ cond('len, 'i) } do
+                ${ perElem('{ if a ne null then ${ read('a, 'i).asExprOf[se] } else ${ readAtKind(elemTpe, 's, 'i).asExprOf[se] } }.asTerm) }
+                i += 1
+            }
+      k match
+        case Kind.KInt =>
+          skeleton[Array[Int]](
+            s =>
+              if mat then '{ $s match { case l: IntArr => l.arr; case t => if t.length >= 64 then FArrayOps.materializeInt(t) else null } }
+              else '{ $s match { case l: IntArr => l.arr; case _ => null } },
+            (a, i) => '{ $a($i) }.asTerm
+          )
+        case Kind.KLong =>
+          skeleton[Array[Long]](
+            s =>
+              if mat then '{ $s match { case l: LongArr => l.arr; case t => if t.length >= 64 then FArrayOps.materializeLong(t) else null } }
+              else '{ $s match { case l: LongArr => l.arr; case _ => null } },
+            (a, i) => '{ $a($i) }.asTerm
+          )
+        case Kind.KDouble =>
+          skeleton[Array[Double]](
+            s =>
+              if mat then '{ $s match { case l: DoubleArr => l.arr; case t => if t.length >= 64 then FArrayOps.materializeDouble(t) else null } }
+              else '{ $s match { case l: DoubleArr => l.arr; case _ => null } },
+            (a, i) => '{ $a($i) }.asTerm
+          )
+        case Kind.KFloat =>
+          skeleton[Array[Float]](
+            s =>
+              if mat then '{ $s match { case l: FloatArr => l.arr; case t => if t.length >= 64 then FArrayOps.materializeFloat(t) else null } }
+              else '{ $s match { case l: FloatArr => l.arr; case _ => null } },
+            (a, i) => '{ $a($i) }.asTerm
+          )
+        case Kind.KShort =>
+          skeleton[Array[Short]](
+            s =>
+              if mat then '{ $s match { case l: ShortArr => l.arr; case t => if t.length >= 64 then FArrayOps.materializeShort(t) else null } }
+              else '{ $s match { case l: ShortArr => l.arr; case _ => null } },
+            (a, i) => '{ $a($i) }.asTerm
+          )
+        case Kind.KByte =>
+          skeleton[Array[Byte]](
+            s =>
+              if mat then '{ $s match { case l: ByteArr => l.arr; case t => if t.length >= 64 then FArrayOps.materializeByte(t) else null } }
+              else '{ $s match { case l: ByteArr => l.arr; case _ => null } },
+            (a, i) => '{ $a($i) }.asTerm
+          )
+        case Kind.KChar =>
+          skeleton[Array[Char]](
+            s =>
+              if mat then '{ $s match { case l: CharArr => l.arr; case t => if t.length >= 64 then FArrayOps.materializeChar(t) else null } }
+              else '{ $s match { case l: CharArr => l.arr; case _ => null } },
+            (a, i) => '{ $a($i) }.asTerm
+          )
+        case Kind.KBoolean =>
+          skeleton[Array[Boolean]](
+            s =>
+              if mat then '{ $s match { case l: BooleanArr => l.arr; case t => if t.length >= 64 then FArrayOps.materializeBoolean(t) else null } }
+              else '{ $s match { case l: BooleanArr => l.arr; case _ => null } },
+            (a, i) => '{ $a($i) }.asTerm
+          )
+        case Kind.KRef =>
+          skeleton[Array[AnyRef]](
+            s =>
+              if mat then '{ $s match { case l: RefArr => l.arr; case t => if t.length >= 64 then FArrayOps.materializeRef(t) else null } }
+              else '{ $s match { case l: RefArr => l.arr; case _ => null } },
+            (a, i) => elemTpe.asType match { case '[b] => '{ $a($i).asInstanceOf[b] }.asTerm }
+          )
 
     // in-memory: ONE chunk = the whole FArray. Just the shared element loop.
-    def loopOver(src: Expr[FBase], k: Kind, elemTpe: TypeRepr, ss: List[(Stage, Int)], ctx: Ctx): Expr[Unit] =
-      elementLoop(src, k, elemTpe, ss, ctx)
+    def loopOver(src: Expr[FBase], k: Kind, elemTpe: TypeRepr, ss: List[(Stage, Int)], ctx: Ctx, outer: Boolean): Expr[Unit] =
+      elementLoop(src, k, elemTpe, ss, ctx, outer)
 
     // streaming: drive a `Source` — pull a chunk, run the shared element loop over it, repeat. CONSTANT MEMORY:
     // live data = stage state (hoisted above by withDone/declareSlots) + ONE chunk's backing array. `done` is
@@ -1349,7 +1345,7 @@ object FuseMacro:
         try
           var chunk: FArray[Any] | Source.End = src.pullChunk().asInstanceOf[FArray[Any] | Source.End]
           while (chunk ne Source.End) && $notDone do
-            ${ elementLoop('{ chunk.asInstanceOf[FArray[Any]].asInstanceOf[FBase] }, k, elemTpe, ss, ctx) }
+            ${ elementLoop('{ chunk.asInstanceOf[FArray[Any]].asInstanceOf[FBase] }, k, elemTpe, ss, ctx, outer = true) }
             chunk = if $notDone then src.pullChunk().asInstanceOf[FArray[Any] | Source.End] else Source.End
         finally src.close()
       }
@@ -1744,7 +1740,7 @@ object FuseMacro:
         (decomposedSrc, streamSrc) match
           case (Some(js), _) => RecordDecoder.lower(decoderInput(js, c))
           case (_, Some(ss)) => withEpilogue(c, withScanPrologue(c, loopOverSource(ss, srcK, srcElem, indexed, c)))
-          case _             => withEpilogue(c, withScanPrologue(c, loopOver(src0, srcK, srcElem, indexed, c)))
+          case _             => withEpilogue(c, withScanPrologue(c, loopOver(src0, srcK, srcElem, indexed, c, outer = true)))
       def loop(consume: Term => Term): Expr[Unit] = drive(ctx(consume))
       // shape-aware driver: the terminal consumes the element's decomposed Shape (so `op`/`f` projects columns
       // without rebuilding the product). `consume` is a materialize-then-apply fallback for non-segment paths.
@@ -2110,7 +2106,7 @@ object FuseMacro:
         (decomposedSrc, streamSrc) match
           case (Some(js), _) => RecordDecoder.lower(decoderInput(js, c))
           case (_, Some(ss)) => withEpilogue(c, withScanPrologue(c, loopOverSource(ss, srcK, srcElem, indexed, c)))
-          case _             => withEpilogue(c, withScanPrologue(c, loopOver(src0, srcK, srcElem, indexed, c)))
+          case _             => withEpilogue(c, withScanPrologue(c, loopOver(src0, srcK, srcElem, indexed, c, outer = true)))
       outK match
         case Kind.KInt =>
           if needsGrow then

--- a/tests/snapshots/fuse-collect-zip.snap
+++ b/tests/snapshots/fuse-collect-zip.snap
@@ -20,54 +20,34 @@
     val cap: Int = java.lang.Math.min(n0, zn)
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val `a₂`: Array[Int] = leaf.arr
-        val len: Int = `a₂`.length
-        var i: Int = 0
-        while (i.<(len).&&(done.unary_!)) {
-          val v: Int = `a₂`.apply(i)
-          if (c.>=(zn)) done = true else {
-            val pos: Int = c
-            c = c.+(1)
-            val `v₂`: Int = FArrayOps.intAt(zthat, pos)
-            new Tuple2$mcII$sp(v, `v₂`).asInstanceOf[Tuple2[Int, Int]] match {
-              case Tuple2(a, b) if `a₃`.+(`b₂`).%(2).==(0) =>
-                {
-                  val `v₃`: Int = `a₃`.*(`b₂`)
-                  val `v₄`: Int = `v₃`.+(1)
-                  out.update(o, `v₄`)
-                  o = o.+(1)
-                }
-              case _ =>
-                ()
+    val s: FBase = src0
+    val `a₂`: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case _ =>
+        null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len).&&(done.unary_!)) {
+      val v: Int = if (`a₂`.ne(null)) `a₂`.apply(i) else FArrayOps.intAt(s, i)
+      if (c.>=(zn)) done = true else {
+        val pos: Int = c
+        c = c.+(1)
+        val `v₂`: Int = FArrayOps.intAt(zthat, pos)
+        new Tuple2$mcII$sp(v, `v₂`).asInstanceOf[Tuple2[Int, Int]] match {
+          case Tuple2(a, b) if `a₃`.+(`b₂`).%(2).==(0) =>
+            {
+              val `v₃`: Int = `a₃`.*(`b₂`)
+              val `v₄`: Int = `v₃`.+(1)
+              out.update(o, `v₄`)
+              o = o.+(1)
             }
-          }
-          i = i.+(1)
+          case _ =>
+            ()
         }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
-          val `v₅`: Int = FArrayOps.intAt(s, `i₂`)
-          if (c.>=(zn)) done = true else {
-            val `pos₂`: Int = c
-            c = c.+(1)
-            val `v₆`: Int = FArrayOps.intAt(zthat, `pos₂`)
-            new Tuple2$mcII$sp(`v₅`, `v₆`).asInstanceOf[Tuple2[Int, Int]] match {
-              case Tuple2(a, b) if `a₄`.+(`b₃`).%(2).==(0) =>
-                {
-                  val `v₇`: Int = `a₄`.*(`b₃`)
-                  val `v₈`: Int = `v₇`.+(1)
-                  out.update(o, `v₈`)
-                  o = o.+(1)
-                }
-              case _ =>
-                ()
-            }
-          }
-          `i₂` = `i₂`.+(1)
-        }
+      }
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])

--- a/tests/snapshots/fuse-long-pipeline.snap
+++ b/tests/snapshots/fuse-long-pipeline.snap
@@ -75,314 +75,164 @@
       var acc: Int = 0
 
       ({
-        src0 match {
-          case leaf: IntArr =>
-            val `a₂`: Array[Int] = leaf.arr
-            val len: Int = `a₂`.length
-            var `i₃`: Int = 0
-            while (`i₃`.<(len).&&(done.unary_!)) {
-              val `v₃`: Int = `a₂`.apply(`i₃`)
-              val `v₄`: Int = `v₃`.%(3)
-              val `v₅`: Boolean = `v₄`.!=(0)
-              if (`v₅`) {
-                val `v₆`: Int = `v₃`.*(2)
-                val `v₇`: Int = `v₆`.%(2)
-                val `v₈`: Boolean = `v₇`.==(0)
-                if (`v₈`) {
-                  val `v₉`: Int = `v₆`.-(7)
-                  if (c.>=(zn)) done = true else {
-                    val pos: Int = c
-                    c = c.+(1)
-                    val `v₁₀`: Int = FArrayOps.intAt(zthat, pos)
-                    val `v₁₁`: Int = `v₉`.+(`v₁₀`)
-                    val `v₁₂`: Int = `c₂`
-                    `c₂` = `c₂`.+(1)
-                    val `v₁₃`: Int = `v₁₁`.+(`v₁₂`)
-                    val `v₁₄`: Int = `v₁₃`.%(4)
-                    val `v₁₅`: Boolean = `v₁₄`.!=(0)
-                    if (`v₁₅`) {
-                      val `v₁₆`: Int = `v₁₁`.-(`v₁₂`)
-                      val `v₁₇`: Boolean = `v₁₆`.>(0)
-                      if (`v₁₇`) {
-                        acc = acc.+(`v₁₆`)
-                        ()
-                      } else ()
-                      val `v₁₈`: Int = `v₁₆`.+(3)
-                      val `v₁₉`: Boolean = `v₁₈`.>(0)
-                      if (`v₁₉`) {
-                        val `v₂₀`: Int = `v₁₆`.+(3)
-                        acc = acc.+(`v₂₀`)
-                        ()
-                      } else ()
-                      ()
-                    } else ()
-                  }
+        val s: FBase = src0
+        val `a₂`: Array[Int] = s match {
+          case l: IntArr =>
+            (l.arr: Array[Int])
+          case _ =>
+            null
+        }
+        val len: Int = s.length
+        var `i₃`: Int = 0
+        while (`i₃`.<(len).&&(done.unary_!)) {
+          val `v₃`: Int = if (`a₂`.ne(null)) `a₂`.apply(`i₃`) else FArrayOps.intAt(s, `i₃`)
+          val `v₄`: Int = `v₃`.%(3)
+          val `v₅`: Boolean = `v₄`.!=(0)
+          if (`v₅`) {
+            val `v₆`: Int = `v₃`.*(2)
+            val `v₇`: Int = `v₆`.%(2)
+            val `v₈`: Boolean = `v₇`.==(0)
+            if (`v₈`) {
+              val `v₉`: Int = `v₆`.-(7)
+              if (c.>=(zn)) done = true else {
+                val pos: Int = c
+                c = c.+(1)
+                val `v₁₀`: Int = FArrayOps.intAt(zthat, pos)
+                val `v₁₁`: Int = `v₉`.+(`v₁₀`)
+                val `v₁₂`: Int = `c₂`
+                `c₂` = `c₂`.+(1)
+                val `v₁₃`: Int = `v₁₁`.+(`v₁₂`)
+                val `v₁₄`: Int = `v₁₃`.%(4)
+                val `v₁₅`: Boolean = `v₁₄`.!=(0)
+                if (`v₁₅`) {
+                  val `v₁₆`: Int = `v₁₁`.-(`v₁₂`)
+                  val `v₁₇`: Boolean = `v₁₆`.>(0)
+                  if (`v₁₇`) {
+                    acc = acc.+(`v₁₆`)
+                    ()
+                  } else ()
+                  val `v₁₈`: Int = `v₁₆`.+(3)
+                  val `v₁₉`: Boolean = `v₁₈`.>(0)
+                  if (`v₁₉`) {
+                    val `v₂₀`: Int = `v₁₆`.+(3)
+                    acc = acc.+(`v₂₀`)
+                    ()
+                  } else ()
+                  ()
                 } else ()
-                val `v₂₁`: Int = `v₆`.^(5)
-                val `v₂₂`: Int = `v₂₁`.%(2)
-                val `v₂₃`: Boolean = `v₂₂`.==(0)
-                if (`v₂₃`) {
-                  val `v₂₄`: Int = `v₆`.^(5)
-                  val `v₂₅`: Int = `v₂₄`.-(7)
-                  if (c.>=(zn)) done = true else {
-                    val `pos₂`: Int = c
-                    c = c.+(1)
-                    val `v₂₆`: Int = FArrayOps.intAt(zthat, `pos₂`)
-                    val `v₂₇`: Int = `v₂₅`.+(`v₂₆`)
-                    val `v₂₈`: Int = `c₂`
-                    `c₂` = `c₂`.+(1)
-                    val `v₂₉`: Int = `v₂₇`.+(`v₂₈`)
-                    val `v₃₀`: Int = `v₂₉`.%(4)
-                    val `v₃₁`: Boolean = `v₃₀`.!=(0)
-                    if (`v₃₁`) {
-                      val `v₃₂`: Int = `v₂₇`.-(`v₂₈`)
-                      val `v₃₃`: Boolean = `v₃₂`.>(0)
-                      if (`v₃₃`) {
-                        acc = acc.+(`v₃₂`)
-                        ()
-                      } else ()
-                      val `v₃₄`: Int = `v₃₂`.+(3)
-                      val `v₃₅`: Boolean = `v₃₄`.>(0)
-                      if (`v₃₅`) {
-                        val `v₃₆`: Int = `v₃₂`.+(3)
-                        acc = acc.+(`v₃₆`)
-                        ()
-                      } else ()
-                      ()
-                    } else ()
-                  }
+              }
+            } else ()
+            val `v₂₁`: Int = `v₆`.^(5)
+            val `v₂₂`: Int = `v₂₁`.%(2)
+            val `v₂₃`: Boolean = `v₂₂`.==(0)
+            if (`v₂₃`) {
+              val `v₂₄`: Int = `v₆`.^(5)
+              val `v₂₅`: Int = `v₂₄`.-(7)
+              if (c.>=(zn)) done = true else {
+                val `pos₂`: Int = c
+                c = c.+(1)
+                val `v₂₆`: Int = FArrayOps.intAt(zthat, `pos₂`)
+                val `v₂₇`: Int = `v₂₅`.+(`v₂₆`)
+                val `v₂₈`: Int = `c₂`
+                `c₂` = `c₂`.+(1)
+                val `v₂₉`: Int = `v₂₇`.+(`v₂₈`)
+                val `v₃₀`: Int = `v₂₉`.%(4)
+                val `v₃₁`: Boolean = `v₃₀`.!=(0)
+                if (`v₃₁`) {
+                  val `v₃₂`: Int = `v₂₇`.-(`v₂₈`)
+                  val `v₃₃`: Boolean = `v₃₂`.>(0)
+                  if (`v₃₃`) {
+                    acc = acc.+(`v₃₂`)
+                    ()
+                  } else ()
+                  val `v₃₄`: Int = `v₃₂`.+(3)
+                  val `v₃₅`: Boolean = `v₃₄`.>(0)
+                  if (`v₃₅`) {
+                    val `v₃₆`: Int = `v₃₂`.+(3)
+                    acc = acc.+(`v₃₆`)
+                    ()
+                  } else ()
+                  ()
                 } else ()
-                ()
-              } else ()
-              val `v₃₇`: Int = `v₃`.+(1)
-              val `v₃₈`: Int = `v₃₇`.%(3)
-              val `v₃₉`: Boolean = `v₃₈`.!=(0)
-              if (`v₃₉`) {
-                val `v₄₀`: Int = `v₃`.+(1)
-                val `v₄₁`: Int = `v₄₀`.*(2)
-                val `v₄₂`: Int = `v₄₁`.%(2)
-                val `v₄₃`: Boolean = `v₄₂`.==(0)
-                if (`v₄₃`) {
-                  val `v₄₄`: Int = `v₄₁`.-(7)
-                  if (c.>=(zn)) done = true else {
-                    val `pos₃`: Int = c
-                    c = c.+(1)
-                    val `v₄₅`: Int = FArrayOps.intAt(zthat, `pos₃`)
-                    val `v₄₆`: Int = `v₄₄`.+(`v₄₅`)
-                    val `v₄₇`: Int = `c₂`
-                    `c₂` = `c₂`.+(1)
-                    val `v₄₈`: Int = `v₄₆`.+(`v₄₇`)
-                    val `v₄₉`: Int = `v₄₈`.%(4)
-                    val `v₅₀`: Boolean = `v₄₉`.!=(0)
-                    if (`v₅₀`) {
-                      val `v₅₁`: Int = `v₄₆`.-(`v₄₇`)
-                      val `v₅₂`: Boolean = `v₅₁`.>(0)
-                      if (`v₅₂`) {
-                        acc = acc.+(`v₅₁`)
-                        ()
-                      } else ()
-                      val `v₅₃`: Int = `v₅₁`.+(3)
-                      val `v₅₄`: Boolean = `v₅₃`.>(0)
-                      if (`v₅₄`) {
-                        val `v₅₅`: Int = `v₅₁`.+(3)
-                        acc = acc.+(`v₅₅`)
-                        ()
-                      } else ()
-                      ()
-                    } else ()
-                  }
+              }
+            } else ()
+            ()
+          } else ()
+          val `v₃₇`: Int = `v₃`.+(1)
+          val `v₃₈`: Int = `v₃₇`.%(3)
+          val `v₃₉`: Boolean = `v₃₈`.!=(0)
+          if (`v₃₉`) {
+            val `v₄₀`: Int = `v₃`.+(1)
+            val `v₄₁`: Int = `v₄₀`.*(2)
+            val `v₄₂`: Int = `v₄₁`.%(2)
+            val `v₄₃`: Boolean = `v₄₂`.==(0)
+            if (`v₄₃`) {
+              val `v₄₄`: Int = `v₄₁`.-(7)
+              if (c.>=(zn)) done = true else {
+                val `pos₃`: Int = c
+                c = c.+(1)
+                val `v₄₅`: Int = FArrayOps.intAt(zthat, `pos₃`)
+                val `v₄₆`: Int = `v₄₄`.+(`v₄₅`)
+                val `v₄₇`: Int = `c₂`
+                `c₂` = `c₂`.+(1)
+                val `v₄₈`: Int = `v₄₆`.+(`v₄₇`)
+                val `v₄₉`: Int = `v₄₈`.%(4)
+                val `v₅₀`: Boolean = `v₄₉`.!=(0)
+                if (`v₅₀`) {
+                  val `v₅₁`: Int = `v₄₆`.-(`v₄₇`)
+                  val `v₅₂`: Boolean = `v₅₁`.>(0)
+                  if (`v₅₂`) {
+                    acc = acc.+(`v₅₁`)
+                    ()
+                  } else ()
+                  val `v₅₃`: Int = `v₅₁`.+(3)
+                  val `v₅₄`: Boolean = `v₅₃`.>(0)
+                  if (`v₅₄`) {
+                    val `v₅₅`: Int = `v₅₁`.+(3)
+                    acc = acc.+(`v₅₅`)
+                    ()
+                  } else ()
+                  ()
                 } else ()
-                val `v₅₆`: Int = `v₄₁`.^(5)
-                val `v₅₇`: Int = `v₅₆`.%(2)
-                val `v₅₈`: Boolean = `v₅₇`.==(0)
-                if (`v₅₈`) {
-                  val `v₅₉`: Int = `v₄₁`.^(5)
-                  val `v₆₀`: Int = `v₅₉`.-(7)
-                  if (c.>=(zn)) done = true else {
-                    val `pos₄`: Int = c
-                    c = c.+(1)
-                    val `v₆₁`: Int = FArrayOps.intAt(zthat, `pos₄`)
-                    val `v₆₂`: Int = `v₆₀`.+(`v₆₁`)
-                    val `v₆₃`: Int = `c₂`
-                    `c₂` = `c₂`.+(1)
-                    val `v₆₄`: Int = `v₆₂`.+(`v₆₃`)
-                    val `v₆₅`: Int = `v₆₄`.%(4)
-                    val `v₆₆`: Boolean = `v₆₅`.!=(0)
-                    if (`v₆₆`) {
-                      val `v₆₇`: Int = `v₆₂`.-(`v₆₃`)
-                      val `v₆₈`: Boolean = `v₆₇`.>(0)
-                      if (`v₆₈`) {
-                        acc = acc.+(`v₆₇`)
-                        ()
-                      } else ()
-                      val `v₆₉`: Int = `v₆₇`.+(3)
-                      val `v₇₀`: Boolean = `v₆₉`.>(0)
-                      if (`v₇₀`) {
-                        val `v₇₁`: Int = `v₆₇`.+(3)
-                        acc = acc.+(`v₇₁`)
-                        ()
-                      } else ()
-                      ()
-                    } else ()
-                  }
+              }
+            } else ()
+            val `v₅₆`: Int = `v₄₁`.^(5)
+            val `v₅₇`: Int = `v₅₆`.%(2)
+            val `v₅₈`: Boolean = `v₅₇`.==(0)
+            if (`v₅₈`) {
+              val `v₅₉`: Int = `v₄₁`.^(5)
+              val `v₆₀`: Int = `v₅₉`.-(7)
+              if (c.>=(zn)) done = true else {
+                val `pos₄`: Int = c
+                c = c.+(1)
+                val `v₆₁`: Int = FArrayOps.intAt(zthat, `pos₄`)
+                val `v₆₂`: Int = `v₆₀`.+(`v₆₁`)
+                val `v₆₃`: Int = `c₂`
+                `c₂` = `c₂`.+(1)
+                val `v₆₄`: Int = `v₆₂`.+(`v₆₃`)
+                val `v₆₅`: Int = `v₆₄`.%(4)
+                val `v₆₆`: Boolean = `v₆₅`.!=(0)
+                if (`v₆₆`) {
+                  val `v₆₇`: Int = `v₆₂`.-(`v₆₃`)
+                  val `v₆₈`: Boolean = `v₆₇`.>(0)
+                  if (`v₆₈`) {
+                    acc = acc.+(`v₆₇`)
+                    ()
+                  } else ()
+                  val `v₆₉`: Int = `v₆₇`.+(3)
+                  val `v₇₀`: Boolean = `v₆₉`.>(0)
+                  if (`v₇₀`) {
+                    val `v₇₁`: Int = `v₆₇`.+(3)
+                    acc = acc.+(`v₇₁`)
+                    ()
+                  } else ()
+                  ()
                 } else ()
-                ()
-              } else ()
-              `i₃` = `i₃`.+(1)
-            }
-          case s =>
-            val `len₂`: Int = s.length
-            var `i₄`: Int = 0
-            while (`i₄`.<(`len₂`).&&(done.unary_!)) {
-              val `v₇₂`: Int = FArrayOps.intAt(s, `i₄`)
-              val `v₇₃`: Int = `v₇₂`.%(3)
-              val `v₇₄`: Boolean = `v₇₃`.!=(0)
-              if (`v₇₄`) {
-                val `v₇₅`: Int = `v₇₂`.*(2)
-                val `v₇₆`: Int = `v₇₅`.%(2)
-                val `v₇₇`: Boolean = `v₇₆`.==(0)
-                if (`v₇₇`) {
-                  val `v₇₈`: Int = `v₇₅`.-(7)
-                  if (c.>=(zn)) done = true else {
-                    val `pos₅`: Int = c
-                    c = c.+(1)
-                    val `v₇₉`: Int = FArrayOps.intAt(zthat, `pos₅`)
-                    val `v₈₀`: Int = `v₇₈`.+(`v₇₉`)
-                    val `v₈₁`: Int = `c₂`
-                    `c₂` = `c₂`.+(1)
-                    val `v₈₂`: Int = `v₈₀`.+(`v₈₁`)
-                    val `v₈₃`: Int = `v₈₂`.%(4)
-                    val `v₈₄`: Boolean = `v₈₃`.!=(0)
-                    if (`v₈₄`) {
-                      val `v₈₅`: Int = `v₈₀`.-(`v₈₁`)
-                      val `v₈₆`: Boolean = `v₈₅`.>(0)
-                      if (`v₈₆`) {
-                        acc = acc.+(`v₈₅`)
-                        ()
-                      } else ()
-                      val `v₈₇`: Int = `v₈₅`.+(3)
-                      val `v₈₈`: Boolean = `v₈₇`.>(0)
-                      if (`v₈₈`) {
-                        val `v₈₉`: Int = `v₈₅`.+(3)
-                        acc = acc.+(`v₈₉`)
-                        ()
-                      } else ()
-                      ()
-                    } else ()
-                  }
-                } else ()
-                val `v₉₀`: Int = `v₇₅`.^(5)
-                val `v₉₁`: Int = `v₉₀`.%(2)
-                val `v₉₂`: Boolean = `v₉₁`.==(0)
-                if (`v₉₂`) {
-                  val `v₉₃`: Int = `v₇₅`.^(5)
-                  val `v₉₄`: Int = `v₉₃`.-(7)
-                  if (c.>=(zn)) done = true else {
-                    val `pos₆`: Int = c
-                    c = c.+(1)
-                    val `v₉₅`: Int = FArrayOps.intAt(zthat, `pos₆`)
-                    val `v₉₆`: Int = `v₉₄`.+(`v₉₅`)
-                    val `v₉₇`: Int = `c₂`
-                    `c₂` = `c₂`.+(1)
-                    val `v₉₈`: Int = `v₉₆`.+(`v₉₇`)
-                    val `v₉₉`: Int = `v₉₈`.%(4)
-                    val `v₁₀₀`: Boolean = `v₉₉`.!=(0)
-                    if (`v₁₀₀`) {
-                      val `v₁₀₁`: Int = `v₉₆`.-(`v₉₇`)
-                      val `v₁₀₂`: Boolean = `v₁₀₁`.>(0)
-                      if (`v₁₀₂`) {
-                        acc = acc.+(`v₁₀₁`)
-                        ()
-                      } else ()
-                      val `v₁₀₃`: Int = `v₁₀₁`.+(3)
-                      val `v₁₀₄`: Boolean = `v₁₀₃`.>(0)
-                      if (`v₁₀₄`) {
-                        val `v₁₀₅`: Int = `v₁₀₁`.+(3)
-                        acc = acc.+(`v₁₀₅`)
-                        ()
-                      } else ()
-                      ()
-                    } else ()
-                  }
-                } else ()
-                ()
-              } else ()
-              val `v₁₀₆`: Int = `v₇₂`.+(1)
-              val `v₁₀₇`: Int = `v₁₀₆`.%(3)
-              val `v₁₀₈`: Boolean = `v₁₀₇`.!=(0)
-              if (`v₁₀₈`) {
-                val `v₁₀₉`: Int = `v₇₂`.+(1)
-                val `v₁₁₀`: Int = `v₁₀₉`.*(2)
-                val `v₁₁₁`: Int = `v₁₁₀`.%(2)
-                val `v₁₁₂`: Boolean = `v₁₁₁`.==(0)
-                if (`v₁₁₂`) {
-                  val `v₁₁₃`: Int = `v₁₁₀`.-(7)
-                  if (c.>=(zn)) done = true else {
-                    val `pos₇`: Int = c
-                    c = c.+(1)
-                    val `v₁₁₄`: Int = FArrayOps.intAt(zthat, `pos₇`)
-                    val `v₁₁₅`: Int = `v₁₁₃`.+(`v₁₁₄`)
-                    val `v₁₁₆`: Int = `c₂`
-                    `c₂` = `c₂`.+(1)
-                    val `v₁₁₇`: Int = `v₁₁₅`.+(`v₁₁₆`)
-                    val `v₁₁₈`: Int = `v₁₁₇`.%(4)
-                    val `v₁₁₉`: Boolean = `v₁₁₈`.!=(0)
-                    if (`v₁₁₉`) {
-                      val `v₁₂₀`: Int = `v₁₁₅`.-(`v₁₁₆`)
-                      val `v₁₂₁`: Boolean = `v₁₂₀`.>(0)
-                      if (`v₁₂₁`) {
-                        acc = acc.+(`v₁₂₀`)
-                        ()
-                      } else ()
-                      val `v₁₂₂`: Int = `v₁₂₀`.+(3)
-                      val `v₁₂₃`: Boolean = `v₁₂₂`.>(0)
-                      if (`v₁₂₃`) {
-                        val `v₁₂₄`: Int = `v₁₂₀`.+(3)
-                        acc = acc.+(`v₁₂₄`)
-                        ()
-                      } else ()
-                      ()
-                    } else ()
-                  }
-                } else ()
-                val `v₁₂₅`: Int = `v₁₁₀`.^(5)
-                val `v₁₂₆`: Int = `v₁₂₅`.%(2)
-                val `v₁₂₇`: Boolean = `v₁₂₆`.==(0)
-                if (`v₁₂₇`) {
-                  val `v₁₂₈`: Int = `v₁₁₀`.^(5)
-                  val `v₁₂₉`: Int = `v₁₂₈`.-(7)
-                  if (c.>=(zn)) done = true else {
-                    val `pos₈`: Int = c
-                    c = c.+(1)
-                    val `v₁₃₀`: Int = FArrayOps.intAt(zthat, `pos₈`)
-                    val `v₁₃₁`: Int = `v₁₂₉`.+(`v₁₃₀`)
-                    val `v₁₃₂`: Int = `c₂`
-                    `c₂` = `c₂`.+(1)
-                    val `v₁₃₃`: Int = `v₁₃₁`.+(`v₁₃₂`)
-                    val `v₁₃₄`: Int = `v₁₃₃`.%(4)
-                    val `v₁₃₅`: Boolean = `v₁₃₄`.!=(0)
-                    if (`v₁₃₅`) {
-                      val `v₁₃₆`: Int = `v₁₃₁`.-(`v₁₃₂`)
-                      val `v₁₃₇`: Boolean = `v₁₃₆`.>(0)
-                      if (`v₁₃₇`) {
-                        acc = acc.+(`v₁₃₆`)
-                        ()
-                      } else ()
-                      val `v₁₃₈`: Int = `v₁₃₆`.+(3)
-                      val `v₁₃₉`: Boolean = `v₁₃₈`.>(0)
-                      if (`v₁₃₉`) {
-                        val `v₁₄₀`: Int = `v₁₃₆`.+(3)
-                        acc = acc.+(`v₁₄₀`)
-                        ()
-                      } else ()
-                      ()
-                    } else ()
-                  }
-                } else ()
-                ()
-              } else ()
-              `i₄` = `i₄`.+(1)
-            }
+              }
+            } else ()
+            ()
+          } else ()
+          `i₃` = `i₃`.+(1)
         }
         acc
       }: Int)

--- a/tests/snapshots/fuse-opt-cse.snap
+++ b/tests/snapshots/fuse-opt-cse.snap
@@ -13,34 +13,24 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = a.apply(i)
-          val `v₂`: Int = v.*(v)
-          val `v₃`: Int = `v₂`.+(1)
-          val `v₄`: Int = `v₂`.+(2)
-          val `v₅`: Int = `v₃`.+(`v₄`)
-          out.update(o, `v₅`)
-          o = o.+(1)
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`)) {
-          val `v₆`: Int = FArrayOps.intAt(s, `i₂`)
-          val `v₇`: Int = `v₆`.*(`v₆`)
-          val `v₈`: Int = `v₇`.+(1)
-          val `v₉`: Int = `v₇`.+(2)
-          val `v₁₀`: Int = `v₈`.+(`v₉`)
-          out.update(o, `v₁₀`)
-          o = o.+(1)
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case t =>
+        if (`t₂`.length.>=(64)) FArrayOps.materializeInt(`t₂`) else null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      val `v₂`: Int = v.*(v)
+      val `v₃`: Int = `v₂`.+(1)
+      val `v₄`: Int = `v₂`.+(2)
+      val `v₅`: Int = `v₃`.+(`v₄`)
+      out.update(o, `v₅`)
+      o = o.+(1)
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])

--- a/tests/snapshots/fuse-opt-dce.snap
+++ b/tests/snapshots/fuse-opt-dce.snap
@@ -13,36 +13,25 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = a.apply(i)
-          val `v₂`: Int = v.%(3)
-          val `v₃`: Boolean = `v₂`.==(0)
-          if (`v₃`) {
-            val `v₄`: Int = v.*(7)
-            out.update(o, `v₄`)
-            o = o.+(1)
-          } else ()
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`)) {
-          val `v₅`: Int = FArrayOps.intAt(s, `i₂`)
-          val `v₆`: Int = `v₅`.%(3)
-          val `v₇`: Boolean = `v₆`.==(0)
-          if (`v₇`) {
-            val `v₈`: Int = `v₅`.*(7)
-            out.update(o, `v₈`)
-            o = o.+(1)
-          } else ()
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case t =>
+        if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      val `v₂`: Int = v.%(3)
+      val `v₃`: Boolean = `v₂`.==(0)
+      if (`v₃`) {
+        val `v₄`: Int = v.*(7)
+        out.update(o, `v₄`)
+        o = o.+(1)
+      } else ()
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])

--- a/tests/snapshots/fuse-opt-fold.snap
+++ b/tests/snapshots/fuse-opt-fold.snap
@@ -16,26 +16,20 @@
       var acc: Int = 0
 
       ({
-        src0 match {
-          case leaf: IntArr =>
-            val a: Array[Int] = leaf.arr
-            val len: Int = a.length
-            var i: Int = 0
-            while (i.<(len)) {
-              val v: Int = a.apply(i)
-              val `v₂`: Int = v.*(100)
-              acc = acc.+(`v₂`)
-              i = i.+(1)
-            }
-          case s =>
-            val `len₂`: Int = s.length
-            var `i₂`: Int = 0
-            while (`i₂`.<(`len₂`)) {
-              val `v₃`: Int = FArrayOps.intAt(s, `i₂`)
-              val `v₄`: Int = `v₃`.*(100)
-              acc = acc.+(`v₄`)
-              `i₂` = `i₂`.+(1)
-            }
+        val s: FBase = src0
+        val a: Array[Int] = s match {
+          case l: IntArr =>
+            (l.arr: Array[Int])
+          case t =>
+            if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+        }
+        val len: Int = s.length
+        var i: Int = 0
+        while (i.<(len)) {
+          val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+          val `v₂`: Int = v.*(100)
+          acc = acc.+(`v₂`)
+          i = i.+(1)
         }
         acc
       }: Int)

--- a/tests/snapshots/fuse-opt-oneloop.snap
+++ b/tests/snapshots/fuse-opt-oneloop.snap
@@ -13,38 +13,26 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = a.apply(i)
-          val `v₂`: Int = v.+(1)
-          val `v₃`: Int = `v₂`.%(2)
-          val `v₄`: Boolean = `v₃`.==(0)
-          if (`v₄`) {
-            val `v₅`: Int = `v₂`.*(2)
-            out.update(o, `v₅`)
-            o = o.+(1)
-          } else ()
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`)) {
-          val `v₆`: Int = FArrayOps.intAt(s, `i₂`)
-          val `v₇`: Int = `v₆`.+(1)
-          val `v₈`: Int = `v₇`.%(2)
-          val `v₉`: Boolean = `v₈`.==(0)
-          if (`v₉`) {
-            val `v₁₀`: Int = `v₇`.*(2)
-            out.update(o, `v₁₀`)
-            o = o.+(1)
-          } else ()
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case t =>
+        if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      val `v₂`: Int = v.+(1)
+      val `v₃`: Int = `v₂`.%(2)
+      val `v₄`: Boolean = `v₃`.==(0)
+      if (`v₄`) {
+        val `v₅`: Int = `v₂`.*(2)
+        out.update(o, `v₅`)
+        o = o.+(1)
+      } else ()
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])

--- a/tests/snapshots/fuse-opt-sink.snap
+++ b/tests/snapshots/fuse-opt-sink.snap
@@ -20,36 +20,25 @@
         var acc: Int = z$proxy
 
         ({
-          src0 match {
-            case leaf: IntArr =>
-              val a: Array[Int] = leaf.arr
-              val len: Int = a.length
-              var i: Int = 0
-              while (i.<(len)) {
-                val v: Int = a.apply(i)
-                val `v₂`: Int = v.%(2)
-                val `v₃`: Boolean = `v₂`.==(0)
-                if (`v₃`) {
-                  val `v₄`: Int = expensive(v)
-                  acc = IntIsIntegral.plus(acc, `v₄`)
-                  ()
-                } else ()
-                i = i.+(1)
-              }
-            case s =>
-              val `len₂`: Int = s.length
-              var `i₂`: Int = 0
-              while (`i₂`.<(`len₂`)) {
-                val `v₅`: Int = FArrayOps.intAt(s, `i₂`)
-                val `v₆`: Int = `v₅`.%(2)
-                val `v₇`: Boolean = `v₆`.==(0)
-                if (`v₇`) {
-                  val `v₈`: Int = expensive(`v₅`)
-                  acc = IntIsIntegral.plus(acc, `v₈`)
-                  ()
-                } else ()
-                `i₂` = `i₂`.+(1)
-              }
+          val s: FBase = src0
+          val a: Array[Int] = s match {
+            case l: IntArr =>
+              (l.arr: Array[Int])
+            case t =>
+              if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+          }
+          val len: Int = s.length
+          var i: Int = 0
+          while (i.<(len)) {
+            val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+            val `v₂`: Int = v.%(2)
+            val `v₃`: Boolean = `v₂`.==(0)
+            if (`v₃`) {
+              val `v₄`: Int = expensive(v)
+              acc = IntIsIntegral.plus(acc, `v₄`)
+              ()
+            } else ()
+            i = i.+(1)
           }
           acc
         }: Int)

--- a/tests/snapshots/fused-pipeline.snap
+++ b/tests/snapshots/fused-pipeline.snap
@@ -22,38 +22,26 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = a.apply(i)
-          val `v₂`: Int = v.+(1)
-          val `v₃`: Int = `v₂`.%(2)
-          val `v₄`: Boolean = `v₃`.==(0)
-          if (`v₄`) {
-            val `v₅`: Int = `v₂`.*(2)
-            out.update(o, `v₅`)
-            o = o.+(1)
-          } else ()
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`)) {
-          val `v₆`: Int = FArrayOps.intAt(s, `i₂`)
-          val `v₇`: Int = `v₆`.+(1)
-          val `v₈`: Int = `v₇`.%(2)
-          val `v₉`: Boolean = `v₈`.==(0)
-          if (`v₉`) {
-            val `v₁₀`: Int = `v₇`.*(2)
-            out.update(o, `v₁₀`)
-            o = o.+(1)
-          } else ()
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case t =>
+        if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      val `v₂`: Int = v.+(1)
+      val `v₃`: Int = `v₂`.%(2)
+      val `v₄`: Boolean = `v₃`.==(0)
+      if (`v₄`) {
+        val `v₅`: Int = `v₂`.*(2)
+        out.update(o, `v₅`)
+        o = o.+(1)
+      } else ()
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -84,46 +72,30 @@
     val cap: Int = java.lang.Math.min(n0, lim)
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len).&&(done.unary_!)) {
-          val v: Int = a.apply(i)
-          val `v₂`: Int = v.%(2)
-          val `v₃`: Boolean = `v₂`.==(0)
-          if (`v₃`) {
-            val cv: Int = c
-            if (cv.>=(lim)) done = true else {
-              val `v₄`: Int = v.*(10)
-              out.update(o, `v₄`)
-              o = o.+(1)
-              c = c.+(1)
-              if (cv.+(1).>=(lim)) done = true else ()
-            }
-          } else ()
-          i = i.+(1)
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case _ =>
+        null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len).&&(done.unary_!)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      val `v₂`: Int = v.%(2)
+      val `v₃`: Boolean = `v₂`.==(0)
+      if (`v₃`) {
+        val cv: Int = c
+        if (cv.>=(lim)) done = true else {
+          val `v₄`: Int = v.*(10)
+          out.update(o, `v₄`)
+          o = o.+(1)
+          c = c.+(1)
+          if (cv.+(1).>=(lim)) done = true else ()
         }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
-          val `v₅`: Int = FArrayOps.intAt(s, `i₂`)
-          val `v₆`: Int = `v₅`.%(2)
-          val `v₇`: Boolean = `v₆`.==(0)
-          if (`v₇`) {
-            val `cv₂`: Int = c
-            if (`cv₂`.>=(lim)) done = true else {
-              val `v₈`: Int = `v₅`.*(10)
-              out.update(o, `v₈`)
-              o = o.+(1)
-              c = c.+(1)
-              if (`cv₂`.+(1).>=(lim)) done = true else ()
-            }
-          } else ()
-          `i₂` = `i₂`.+(1)
-        }
+      } else ()
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -160,40 +132,27 @@
     val cap: Int = java.lang.Math.min(n0, `lim₂`)
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len).&&(done.unary_!)) {
-          val v: Int = a.apply(i)
-          if (c.<(lim)) c = c.+(1) else {
-            val cv: Int = `c₂`
-            if (cv.>=(`lim₂`)) done = true else {
-              out.update(o, v)
-              o = o.+(1)
-              `c₂` = `c₂`.+(1)
-              if (cv.+(1).>=(`lim₂`)) done = true else ()
-            }
-          }
-          i = i.+(1)
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case _ =>
+        null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len).&&(done.unary_!)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      if (c.<(lim)) c = c.+(1) else {
+        val cv: Int = `c₂`
+        if (cv.>=(`lim₂`)) done = true else {
+          out.update(o, v)
+          o = o.+(1)
+          `c₂` = `c₂`.+(1)
+          if (cv.+(1).>=(`lim₂`)) done = true else ()
         }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
-          val `v₂`: Int = FArrayOps.intAt(s, `i₂`)
-          if (c.<(lim)) c = c.+(1) else {
-            val `cv₂`: Int = `c₂`
-            if (`cv₂`.>=(`lim₂`)) done = true else {
-              out.update(o, `v₂`)
-              o = o.+(1)
-              `c₂` = `c₂`.+(1)
-              if (`cv₂`.+(1).>=(`lim₂`)) done = true else ()
-            }
-          }
-          `i₂` = `i₂`.+(1)
-        }
+      }
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -220,26 +179,20 @@
       var acc: Int = 0
 
       ({
-        src0 match {
-          case leaf: IntArr =>
-            val a: Array[Int] = leaf.arr
-            val len: Int = a.length
-            var i: Int = 0
-            while (i.<(len)) {
-              val v: Int = a.apply(i)
-              val `v₂`: Int = v.+(1)
-              acc = acc.+(`v₂`)
-              i = i.+(1)
-            }
-          case s =>
-            val `len₂`: Int = s.length
-            var `i₂`: Int = 0
-            while (`i₂`.<(`len₂`)) {
-              val `v₃`: Int = FArrayOps.intAt(s, `i₂`)
-              val `v₄`: Int = `v₃`.+(1)
-              acc = acc.+(`v₄`)
-              `i₂` = `i₂`.+(1)
-            }
+        val s: FBase = src0
+        val a: Array[Int] = s match {
+          case l: IntArr =>
+            (l.arr: Array[Int])
+          case t =>
+            if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+        }
+        val len: Int = s.length
+        var i: Int = 0
+        while (i.<(len)) {
+          val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+          val `v₂`: Int = v.+(1)
+          acc = acc.+(`v₂`)
+          i = i.+(1)
         }
         acc
       }: Int)
@@ -265,28 +218,21 @@
     val cap: Int = n0
     val out: Array[Object] = new Array[Object](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = a.apply(i)
-          val `v₂`: Int = v.*(2)
-          out.update(o, new Tuple2$mcII$sp(v, `v₂`).asInstanceOf[Tuple2[Int, Int]].asInstanceOf[Object])
-          o = o.+(1)
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`)) {
-          val `v₃`: Int = FArrayOps.intAt(s, `i₂`)
-          val `v₄`: Int = `v₃`.*(2)
-          out.update(o, new Tuple2$mcII$sp(`v₃`, `v₄`).asInstanceOf[Tuple2[Int, Int]].asInstanceOf[Object])
-          o = o.+(1)
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case t =>
+        if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      val `v₂`: Int = v.*(2)
+      out.update(o, new Tuple2$mcII$sp(v, `v₂`).asInstanceOf[Tuple2[Int, Int]].asInstanceOf[Object])
+      o = o.+(1)
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new RefOne(out.apply(0)) else if (o.==(cap)) new RefArr(out, o) else new RefArr(java.util.Arrays.copyOf[Object](out, o), o)
   }.asInstanceOf[FArray[Tuple2[Int, Int]]]: FArray[Tuple2[Int, Int]])
@@ -313,34 +259,24 @@
       var c: Int = 0
 
       ({
-        src0 match {
-          case leaf: IntArr =>
-            val a: Array[Int] = leaf.arr
-            val len: Int = a.length
-            var i: Int = 0
-            while (i.<(len)) {
-              val v: Int = a.apply(i)
-              val `v₂`: Int = v.%(2)
-              val `v₃`: Boolean = `v₂`.==(0)
-              if (`v₃`) {
-                c = c.+(1)
-                ()
-              } else ()
-              i = i.+(1)
-            }
-          case s =>
-            val `len₂`: Int = s.length
-            var `i₂`: Int = 0
-            while (`i₂`.<(`len₂`)) {
-              val `v₄`: Int = FArrayOps.intAt(s, `i₂`)
-              val `v₅`: Int = `v₄`.%(2)
-              val `v₆`: Boolean = `v₅`.==(0)
-              if (`v₆`) {
-                c = c.+(1)
-                ()
-              } else ()
-              `i₂` = `i₂`.+(1)
-            }
+        val s: FBase = src0
+        val a: Array[Int] = s match {
+          case l: IntArr =>
+            (l.arr: Array[Int])
+          case t =>
+            if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+        }
+        val len: Int = s.length
+        var i: Int = 0
+        while (i.<(len)) {
+          val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+          val `v₂`: Int = v.%(2)
+          val `v₃`: Boolean = `v₂`.==(0)
+          if (`v₃`) {
+            c = c.+(1)
+            ()
+          } else ()
+          i = i.+(1)
         }
         c
       }: Int)
@@ -366,28 +302,21 @@
     val cap: Int = n0
     val out: Array[Object] = new Array[Object](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: RefArr =>
-        val a: Array[Object] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: String = a.apply(i).asInstanceOf[String]
-          val `v₂`: String = v.toUpperCase()
-          out.update(o, `v₂`.asInstanceOf[Object])
-          o = o.+(1)
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`)) {
-          val `v₃`: String = FArrayOps.refAt(s, `i₂`).asInstanceOf[String]
-          val `v₄`: String = `v₃`.toUpperCase()
-          out.update(o, `v₄`.asInstanceOf[Object])
-          o = o.+(1)
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val a: Array[Object] = s match {
+      case l: RefArr =>
+        (l.arr: Array[Object])
+      case t =>
+        if (t.length.>=(64)) FArrayOps.materializeRef(t) else null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len)) {
+      val v: String = if (a.ne(null)) a.apply(i).asInstanceOf[String] else FArrayOps.refAt(s, i).asInstanceOf[String]
+      val `v₂`: String = v.toUpperCase()
+      out.update(o, `v₂`.asInstanceOf[Object])
+      o = o.+(1)
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new RefOne(out.apply(0)) else if (o.==(cap)) new RefArr(out, o) else new RefArr(java.util.Arrays.copyOf[Object](out, o), o)
   }.asInstanceOf[FArray[String]]: FArray[String])
@@ -411,34 +340,24 @@
     ({
       val src0: FBase = inline$base$i1[String](`Fuse_this₂`).asInstanceOf[FBase]
       val n0: Int = src0.length
-      src0 match {
-        case leaf: RefArr =>
-          val a: Array[Object] = leaf.arr
-          val len: Int = a.length
-          var i: Int = 0
-          while (i.<(len)) {
-            val v: String = a.apply(i).asInstanceOf[String]
-            val `v₂`: StringOps = augmentString(v)
-            val `v₃`: Boolean = `v₂`.nonEmpty
-            if (`v₃`) {
-              System.out.println(v)
-              ()
-            } else ()
-            i = i.+(1)
-          }
-        case s =>
-          val `len₂`: Int = s.length
-          var `i₂`: Int = 0
-          while (`i₂`.<(`len₂`)) {
-            val `v₄`: String = FArrayOps.refAt(s, `i₂`).asInstanceOf[String]
-            val `v₅`: StringOps = augmentString(`v₄`)
-            val `v₆`: Boolean = `v₅`.nonEmpty
-            if (`v₆`) {
-              System.out.println(`v₄`)
-              ()
-            } else ()
-            `i₂` = `i₂`.+(1)
-          }
+      val s: FBase = src0
+      val a: Array[Object] = s match {
+        case l: RefArr =>
+          (l.arr: Array[Object])
+        case t =>
+          if (t.length.>=(64)) FArrayOps.materializeRef(t) else null
+      }
+      val len: Int = s.length
+      var i: Int = 0
+      while (i.<(len)) {
+        val v: String = if (a.ne(null)) a.apply(i).asInstanceOf[String] else FArrayOps.refAt(s, i).asInstanceOf[String]
+        val `v₂`: StringOps = augmentString(v)
+        val `v₃`: Boolean = `v₂`.nonEmpty
+        if (`v₃`) {
+          System.out.println(v)
+          ()
+        } else ()
+        i = i.+(1)
       }
       ()
     }.asInstanceOf[Unit]: Unit)
@@ -476,40 +395,27 @@
     val n0: Int = src0.length
     var `out₂`: Array[Int] = new Array[Int](java.lang.Math.max(8, n0))
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = a.apply(i)
-          val `v₂`: Int = v.+(1)
-          if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-          `out₂`.update(o, `v₂`)
-          o = o.+(1)
-          val `v₃`: Int = v.*(10)
-          val `v₄`: Int = `v₃`.+(1)
-          if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-          `out₂`.update(o, `v₄`)
-          o = o.+(1)
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`)) {
-          val `v₅`: Int = FArrayOps.intAt(s, `i₂`)
-          val `v₆`: Int = `v₅`.+(1)
-          if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-          `out₂`.update(o, `v₆`)
-          o = o.+(1)
-          val `v₇`: Int = `v₅`.*(10)
-          val `v₈`: Int = `v₇`.+(1)
-          if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-          `out₂`.update(o, `v₈`)
-          o = o.+(1)
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case t =>
+        if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      val `v₂`: Int = v.+(1)
+      if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+      `out₂`.update(o, `v₂`)
+      o = o.+(1)
+      val `v₃`: Int = v.*(10)
+      val `v₄`: Int = `v₃`.+(1)
+      if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+      `out₂`.update(o, `v₄`)
+      o = o.+(1)
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(`out₂`.apply(0)) else if (o.==(`out₂`.length)) new IntArr(`out₂`, o) else new IntArr(java.util.Arrays.copyOf(`out₂`, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -532,32 +438,23 @@
     val n0: Int = src0.length
     var done: Boolean = false
     var res: Option[Any] = None
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len).&&(done.unary_!)) {
-          val v: Int = a.apply(i)
-          val `v₂`: Int = v.+(1)
-          if (`v₂`.%(3).==(0)) {
-            res = Some.apply[Any](`v₂`)
-            done = true
-          } else ()
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
-          val `v₃`: Int = FArrayOps.intAt(s, `i₂`)
-          val `v₄`: Int = `v₃`.+(1)
-          if (`v₄`.%(3).==(0)) {
-            res = Some.apply[Any](`v₄`)
-            done = true
-          } else ()
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case _ =>
+        null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len).&&(done.unary_!)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      val `v₂`: Int = v.+(1)
+      if (`v₂`.%(3).==(0)) {
+        res = Some.apply[Any](`v₂`)
+        done = true
+      } else ()
+      i = i.+(1)
     }
 
     (res: Option[Any])
@@ -583,38 +480,26 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = a.apply(i)
-          val `v₂`: Int = c
-          c = c.+(1)
-          val `v₃`: Int = `v₂`.%(2)
-          val `v₄`: Boolean = `v₃`.==(0)
-          if (`v₄`) {
-            out.update(o, v)
-            o = o.+(1)
-          } else ()
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`)) {
-          val `v₅`: Int = FArrayOps.intAt(s, `i₂`)
-          val `v₆`: Int = c
-          c = c.+(1)
-          val `v₇`: Int = `v₆`.%(2)
-          val `v₈`: Boolean = `v₇`.==(0)
-          if (`v₈`) {
-            out.update(o, `v₅`)
-            o = o.+(1)
-          } else ()
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case t =>
+        if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      val `v₂`: Int = c
+      c = c.+(1)
+      val `v₃`: Int = `v₂`.%(2)
+      val `v₄`: Boolean = `v₃`.==(0)
+      if (`v₄`) {
+        out.update(o, v)
+        o = o.+(1)
+      } else ()
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -680,38 +565,26 @@
     val cap: Int = java.lang.Math.min(n0, zn)
     val `out₃`: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val `a₂`: Array[Int] = leaf.arr
-        val len: Int = `a₂`.length
-        var i: Int = 0
-        while (i.<(len).&&(done.unary_!)) {
-          val v: Int = `a₂`.apply(i)
-          if (c.>=(zn)) done = true else {
-            val pos: Int = c
-            c = c.+(1)
-            val `v₂`: Int = FArrayOps.intAt(zthat, pos)
-            val `v₃`: Int = v.+(`v₂`)
-            `out₃`.update(o, `v₃`)
-            o = o.+(1)
-          }
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
-          val `v₄`: Int = FArrayOps.intAt(s, `i₂`)
-          if (c.>=(zn)) done = true else {
-            val `pos₂`: Int = c
-            c = c.+(1)
-            val `v₅`: Int = FArrayOps.intAt(zthat, `pos₂`)
-            val `v₆`: Int = `v₄`.+(`v₅`)
-            `out₃`.update(o, `v₆`)
-            o = o.+(1)
-          }
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val `a₂`: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case _ =>
+        null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len).&&(done.unary_!)) {
+      val v: Int = if (`a₂`.ne(null)) `a₂`.apply(i) else FArrayOps.intAt(s, i)
+      if (c.>=(zn)) done = true else {
+        val pos: Int = c
+        c = c.+(1)
+        val `v₂`: Int = FArrayOps.intAt(zthat, pos)
+        val `v₃`: Int = v.+(`v₂`)
+        `out₃`.update(o, `v₃`)
+        o = o.+(1)
+      }
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(`out₃`.apply(0)) else if (o.==(cap)) new IntArr(`out₃`, o) else new IntArr(java.util.Arrays.copyOf(`out₃`, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -735,34 +608,24 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = a.apply(i)
-          val `v₂`: Int = v.*(v)
-          val `v₃`: Int = `v₂`.+(1)
-          val `v₄`: Int = `v₂`.+(2)
-          val `v₅`: Int = `v₃`.+(`v₄`)
-          out.update(o, `v₅`)
-          o = o.+(1)
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`)) {
-          val `v₆`: Int = FArrayOps.intAt(s, `i₂`)
-          val `v₇`: Int = `v₆`.*(`v₆`)
-          val `v₈`: Int = `v₇`.+(1)
-          val `v₉`: Int = `v₇`.+(2)
-          val `v₁₀`: Int = `v₈`.+(`v₉`)
-          out.update(o, `v₁₀`)
-          o = o.+(1)
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case t =>
+        if (`t₂`.length.>=(64)) FArrayOps.materializeInt(`t₂`) else null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      val `v₂`: Int = v.*(v)
+      val `v₃`: Int = `v₂`.+(1)
+      val `v₄`: Int = `v₂`.+(2)
+      val `v₅`: Int = `v₃`.+(`v₄`)
+      out.update(o, `v₅`)
+      o = o.+(1)
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -786,38 +649,26 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = a.apply(i)
-          val `v₂`: Int = v.+(1)
-          val `v₃`: Int = `v₂`.%(2)
-          val `v₄`: Boolean = `v₃`.==(0)
-          if (`v₄`) {
-            val `v₅`: Int = v.*(1000)
-            out.update(o, `v₅`)
-            o = o.+(1)
-          } else ()
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`)) {
-          val `v₆`: Int = FArrayOps.intAt(s, `i₂`)
-          val `v₇`: Int = `v₆`.+(1)
-          val `v₈`: Int = `v₇`.%(2)
-          val `v₉`: Boolean = `v₈`.==(0)
-          if (`v₉`) {
-            val `v₁₀`: Int = `v₆`.*(1000)
-            out.update(o, `v₁₀`)
-            o = o.+(1)
-          } else ()
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case t =>
+        if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      val `v₂`: Int = v.+(1)
+      val `v₃`: Int = `v₂`.%(2)
+      val `v₄`: Boolean = `v₃`.==(0)
+      if (`v₄`) {
+        val `v₅`: Int = v.*(1000)
+        out.update(o, `v₅`)
+        o = o.+(1)
+      } else ()
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -844,42 +695,28 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = a.apply(i)
-          v match {
-            case x if `x₂`.%(2).==(0) =>
-              {
-                val `v₂`: Int = `x₂`.*(10)
-                out.update(o, `v₂`)
-                o = o.+(1)
-              }
-            case _ =>
-              ()
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case t =>
+        if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      v match {
+        case x if `x₂`.%(2).==(0) =>
+          {
+            val `v₂`: Int = `x₂`.*(10)
+            out.update(o, `v₂`)
+            o = o.+(1)
           }
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`)) {
-          val `v₃`: Int = FArrayOps.intAt(s, `i₂`)
-          `v₃` match {
-            case x if `x₃`.%(2).==(0) =>
-              {
-                val `v₄`: Int = `x₃`.*(10)
-                out.update(o, `v₄`)
-                o = o.+(1)
-              }
-            case _ =>
-              ()
-          }
-          `i₂` = `i₂`.+(1)
-        }
+        case _ =>
+          ()
+      }
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -904,30 +741,22 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len).&&(done.unary_!)) {
-          val v: Int = a.apply(i)
-          if (v.<(5)) {
-            out.update(o, v)
-            o = o.+(1)
-          } else done = true
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
-          val `v₂`: Int = FArrayOps.intAt(s, `i₂`)
-          if (`v₂`.<(5)) {
-            out.update(o, `v₂`)
-            o = o.+(1)
-          } else done = true
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case _ =>
+        null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len).&&(done.unary_!)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      if (v.<(5)) {
+        out.update(o, v)
+        o = o.+(1)
+      } else done = true
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -954,38 +783,26 @@
     if (o.>=(out.length)) out = FArrayOps.ensureCapInt(out, o.+(1)) else ()
     out.update(o, acc0)
     o = o.+(1)
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = a.apply(i)
-          acc0 = {
-            val `_$₂`: Int = acc0
-            `_$₂`.+(v)
-          }
-          val `v₂`: Int = acc0
-          if (o.>=(out.length)) out = FArrayOps.ensureCapInt(out, o.+(1)) else ()
-          out.update(o, `v₂`)
-          o = o.+(1)
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`)) {
-          val `v₃`: Int = FArrayOps.intAt(s, `i₂`)
-          acc0 = {
-            val `_$₃`: Int = acc0
-            `_$₃`.+(`v₃`)
-          }
-          val `v₄`: Int = acc0
-          if (o.>=(out.length)) out = FArrayOps.ensureCapInt(out, o.+(1)) else ()
-          out.update(o, `v₄`)
-          o = o.+(1)
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case t =>
+        if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      acc0 = {
+        val `_$₂`: Int = acc0
+        `_$₂`.+(v)
+      }
+      val `v₂`: Int = acc0
+      if (o.>=(out.length)) out = FArrayOps.ensureCapInt(out, o.+(1)) else ()
+      out.update(o, `v₂`)
+      o = o.+(1)
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(out.length)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -1009,34 +826,24 @@
     var done: Boolean = false
     var idx: Int = -1
     var c: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len).&&(done.unary_!)) {
-          val v: Int = a.apply(i)
-          val `v₂`: Int = v.*(v)
-          if (`v₂`.>(9)) {
-            idx = c
-            done = true
-          } else ()
-          c = c.+(1)
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
-          val `v₃`: Int = FArrayOps.intAt(s, `i₂`)
-          val `v₄`: Int = `v₃`.*(`v₃`)
-          if (`v₄`.>(9)) {
-            idx = c
-            done = true
-          } else ()
-          c = c.+(1)
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case _ =>
+        null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len).&&(done.unary_!)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      val `v₂`: Int = v.*(v)
+      if (`v₂`.>(9)) {
+        idx = c
+        done = true
+      } else ()
+      c = c.+(1)
+      i = i.+(1)
     }
 
     (idx: Int)
@@ -1066,48 +873,31 @@
         val n0: Int = src0.length
         var seeded: Boolean = false
         var acc: Int = null.asInstanceOf[Int]
-        src0 match {
-          case leaf: IntArr =>
-            val a: Array[Int] = leaf.arr
-            val len: Int = a.length
-            var i: Int = 0
-            while (i.<(len)) {
-              val v: Int = a.apply(i)
-              val `v₂`: Int = v.%(2)
-              val `v₃`: Boolean = `v₂`.==(0)
-              if (`v₃`) {
-                if (seeded.unary_!) {
-                  acc = v
-                  seeded = true
-                } else acc = {
-                  val `acc₂`: Int = acc
+        val s: FBase = src0
+        val a: Array[Int] = s match {
+          case l: IntArr =>
+            (l.arr: Array[Int])
+          case t =>
+            if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+        }
+        val len: Int = s.length
+        var i: Int = 0
+        while (i.<(len)) {
+          val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+          val `v₂`: Int = v.%(2)
+          val `v₃`: Boolean = `v₂`.==(0)
+          if (`v₃`) {
+            if (seeded.unary_!) {
+              acc = v
+              seeded = true
+            } else acc = {
+              val `acc₂`: Int = acc
 
-                  (if (Int.lteq(`acc₂`, v)) `acc₂` else v: Int)
-                }
-                ()
-              } else ()
-              i = i.+(1)
+              (if (Int.lteq(`acc₂`, v)) `acc₂` else v: Int)
             }
-          case s =>
-            val `len₂`: Int = s.length
-            var `i₂`: Int = 0
-            while (`i₂`.<(`len₂`)) {
-              val `v₄`: Int = FArrayOps.intAt(s, `i₂`)
-              val `v₅`: Int = `v₄`.%(2)
-              val `v₆`: Boolean = `v₅`.==(0)
-              if (`v₆`) {
-                if (seeded.unary_!) {
-                  acc = `v₄`
-                  seeded = true
-                } else acc = {
-                  val `acc₃`: Int = acc
-
-                  (if (Int.lteq(`acc₃`, `v₄`)) `acc₃` else `v₄`: Int)
-                }
-                ()
-              } else ()
-              `i₂` = `i₂`.+(1)
-            }
+            ()
+          } else ()
+          i = i.+(1)
         }
         if (seeded) Some.apply[Int](acc) else None
       }.asInstanceOf[Option[Int]]: Option[Int])
@@ -1139,40 +929,27 @@
         var seeded: Boolean = false
         var best: Any = null
         var bestK: Int = null.asInstanceOf[Int]
-        src0 match {
-          case leaf: IntArr =>
-            val a: Array[Int] = leaf.arr
-            val len: Int = a.length
-            var i: Int = 0
-            while (i.<(len)) {
-              val v: Int = a.apply(i)
-              val kk: Int = v.unary_-
-              if (seeded.unary_!.||({
-                val k2: Int = bestK
-                Int.lt(kk, k2)
-              })) {
-                best = v
-                bestK = kk
-                seeded = true
-              } else ()
-              i = i.+(1)
-            }
-          case s =>
-            val `len₂`: Int = s.length
-            var `i₂`: Int = 0
-            while (`i₂`.<(`len₂`)) {
-              val `v₂`: Int = FArrayOps.intAt(s, `i₂`)
-              val `kk₂`: Int = `v₂`.unary_-
-              if (seeded.unary_!.||({
-                val `k2₂`: Int = bestK
-                Int.lt(`kk₂`, `k2₂`)
-              })) {
-                best = `v₂`
-                bestK = `kk₂`
-                seeded = true
-              } else ()
-              `i₂` = `i₂`.+(1)
-            }
+        val s: FBase = src0
+        val a: Array[Int] = s match {
+          case l: IntArr =>
+            (l.arr: Array[Int])
+          case t =>
+            if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+        }
+        val len: Int = s.length
+        var i: Int = 0
+        while (i.<(len)) {
+          val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+          val kk: Int = v.unary_-
+          if (seeded.unary_!.||({
+            val k2: Int = bestK
+            Int.lt(kk, k2)
+          })) {
+            best = v
+            bestK = kk
+            seeded = true
+          } else ()
+          i = i.+(1)
         }
         if (seeded) Some.apply[Any](best) else None
       }.asInstanceOf[Option[Int]]: Option[Int])
@@ -1198,30 +975,22 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var `o₂`: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = a.apply(i)
-          val `v₂`: Int = v.*(3)
-          val `v₃`: Int = v.+(`v₂`)
-          out.update(`o₂`, `v₃`)
-          `o₂` = `o₂`.+(1)
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`)) {
-          val `v₄`: Int = FArrayOps.intAt(s, `i₂`)
-          val `v₅`: Int = `v₄`.*(3)
-          val `v₆`: Int = `v₄`.+(`v₅`)
-          out.update(`o₂`, `v₆`)
-          `o₂` = `o₂`.+(1)
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case t =>
+        if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      val `v₂`: Int = v.*(3)
+      val `v₃`: Int = v.+(`v₂`)
+      out.update(`o₂`, `v₃`)
+      `o₂` = `o₂`.+(1)
+      i = i.+(1)
     }
     if (`o₂`.==(0)) (Empty.INSTANCE: FBase) else if (`o₂`.==(1)) new IntOne(out.apply(0)) else if (`o₂`.==(cap)) new IntArr(out, `o₂`) else new IntArr(java.util.Arrays.copyOf(out, `o₂`), `o₂`)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -1252,36 +1021,25 @@
         var acc: Int = z$proxy
 
         ({
-          src0 match {
-            case leaf: IntArr =>
-              val a: Array[Int] = leaf.arr
-              val len: Int = a.length
-              var i: Int = 0
-              while (i.<(len)) {
-                val v: Int = a.apply(i)
-                val `v₂`: Int = v.%(2)
-                val `v₃`: Boolean = `v₂`.==(0)
-                if (`v₃`) {
-                  val `v₄`: Int = v.*(10)
-                  acc = IntIsIntegral.plus(acc, `v₄`)
-                  ()
-                } else ()
-                i = i.+(1)
-              }
-            case s =>
-              val `len₂`: Int = s.length
-              var `i₂`: Int = 0
-              while (`i₂`.<(`len₂`)) {
-                val `v₅`: Int = FArrayOps.intAt(s, `i₂`)
-                val `v₆`: Int = `v₅`.%(2)
-                val `v₇`: Boolean = `v₆`.==(0)
-                if (`v₇`) {
-                  val `v₈`: Int = `v₅`.*(10)
-                  acc = IntIsIntegral.plus(acc, `v₈`)
-                  ()
-                } else ()
-                `i₂` = `i₂`.+(1)
-              }
+          val s: FBase = src0
+          val a: Array[Int] = s match {
+            case l: IntArr =>
+              (l.arr: Array[Int])
+            case t =>
+              if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+          }
+          val len: Int = s.length
+          var i: Int = 0
+          while (i.<(len)) {
+            val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+            val `v₂`: Int = v.%(2)
+            val `v₃`: Boolean = `v₂`.==(0)
+            if (`v₃`) {
+              val `v₄`: Int = v.*(10)
+              acc = IntIsIntegral.plus(acc, `v₄`)
+              ()
+            } else ()
+            i = i.+(1)
           }
           acc
         }: Int)
@@ -1308,28 +1066,21 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = a.apply(i)
-          val `v₂`: Int = v.+(1)
-          out.update(o, `v₂`)
-          o = o.+(1)
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`)) {
-          val `v₃`: Int = FArrayOps.intAt(s, `i₂`)
-          val `v₄`: Int = `v₃`.+(1)
-          out.update(o, `v₄`)
-          o = o.+(1)
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case t =>
+        if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      val `v₂`: Int = v.+(1)
+      out.update(o, `v₂`)
+      o = o.+(1)
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -1393,34 +1144,24 @@
     val cap: Int = java.lang.Math.min(n0, zn)
     val `out₃`: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len).&&(done.unary_!)) {
-          val v: Int = a.apply(i)
-          if (c.>=(zn)) done = true else {
-            val pos: Int = c
-            c = c.+(1)
-            `out₃`.update(o, v)
-            o = o.+(1)
-          }
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
-          val `v₂`: Int = FArrayOps.intAt(s, `i₂`)
-          if (c.>=(zn)) done = true else {
-            val `pos₂`: Int = c
-            c = c.+(1)
-            `out₃`.update(o, `v₂`)
-            o = o.+(1)
-          }
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case _ =>
+        null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len).&&(done.unary_!)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      if (c.>=(zn)) done = true else {
+        val pos: Int = c
+        c = c.+(1)
+        `out₃`.update(o, v)
+        o = o.+(1)
+      }
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(`out₃`.apply(0)) else if (o.==(cap)) new IntArr(`out₃`, o) else new IntArr(java.util.Arrays.copyOf(`out₃`, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -1488,42 +1229,28 @@
     val cap: Int = java.lang.Math.min(n0, zn)
     val `out₃`: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val `a₂`: Array[Int] = leaf.arr
-        val len: Int = `a₂`.length
-        var i: Int = 0
-        while (i.<(len).&&(done.unary_!)) {
-          val v: Int = `a₂`.apply(i)
-          if (c.>=(zn)) done = true else {
-            val pos: Int = c
-            c = c.+(1)
-            val `v₂`: Int = v.%(4)
-            val `v₃`: Boolean = `v₂`.==(0)
-            if (`v₃`) {
-              `out₃`.update(o, v)
-              o = o.+(1)
-            } else ()
-          }
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
-          val `v₄`: Int = FArrayOps.intAt(s, `i₂`)
-          if (c.>=(zn)) done = true else {
-            val `pos₂`: Int = c
-            c = c.+(1)
-            val `v₅`: Int = `v₄`.%(4)
-            val `v₆`: Boolean = `v₅`.==(0)
-            if (`v₆`) {
-              `out₃`.update(o, `v₄`)
-              o = o.+(1)
-            } else ()
-          }
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val `a₂`: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case _ =>
+        null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len).&&(done.unary_!)) {
+      val v: Int = if (`a₂`.ne(null)) `a₂`.apply(i) else FArrayOps.intAt(s, i)
+      if (c.>=(zn)) done = true else {
+        val pos: Int = c
+        c = c.+(1)
+        val `v₂`: Int = v.%(4)
+        val `v₃`: Boolean = `v₂`.==(0)
+        if (`v₃`) {
+          `out₃`.update(o, v)
+          o = o.+(1)
+        } else ()
+      }
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(`out₃`.apply(0)) else if (o.==(cap)) new IntArr(`out₃`, o) else new IntArr(java.util.Arrays.copyOf(`out₃`, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -1550,40 +1277,27 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = a.apply(i)
-          v match {
-            case x if `x₂`.>(2) =>
-              {
-                out.update(o, `x₂`)
-                o = o.+(1)
-              }
-            case _ =>
-              ()
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case t =>
+        if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      v match {
+        case x if `x₂`.>(2) =>
+          {
+            out.update(o, `x₂`)
+            o = o.+(1)
           }
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`)) {
-          val `v₂`: Int = FArrayOps.intAt(s, `i₂`)
-          `v₂` match {
-            case x if `x₃`.>(2) =>
-              {
-                out.update(o, `x₃`)
-                o = o.+(1)
-              }
-            case _ =>
-              ()
-          }
-          `i₂` = `i₂`.+(1)
-        }
+        case _ =>
+          ()
+      }
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -1607,36 +1321,25 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = a.apply(i)
-          val `v₂`: Int = v.+(1)
-          val `v₃`: Boolean = `v₂`.>(2)
-          if (`v₃`) {
-            val `v₄`: Int = `v₂`.*(`v₂`)
-            out.update(o, `v₄`)
-            o = o.+(1)
-          } else ()
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`)) {
-          val `v₅`: Int = FArrayOps.intAt(s, `i₂`)
-          val `v₆`: Int = `v₅`.+(1)
-          val `v₇`: Boolean = `v₆`.>(2)
-          if (`v₇`) {
-            val `v₈`: Int = `v₆`.*(`v₆`)
-            out.update(o, `v₈`)
-            o = o.+(1)
-          } else ()
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case t =>
+        if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      val `v₂`: Int = v.+(1)
+      val `v₃`: Boolean = `v₂`.>(2)
+      if (`v₃`) {
+        val `v₄`: Int = `v₂`.*(`v₂`)
+        out.update(o, `v₄`)
+        o = o.+(1)
+      } else ()
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -1673,40 +1376,27 @@
     val n0: Int = src0.length
     var `out₂`: Array[Int] = new Array[Int](java.lang.Math.max(8, n0))
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = a.apply(i)
-          val `v₂`: Int = v.+(1)
-          if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-          `out₂`.update(o, `v₂`)
-          o = o.+(1)
-          val `v₃`: Int = v.*(10)
-          val `v₄`: Int = `v₃`.+(1)
-          if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-          `out₂`.update(o, `v₄`)
-          o = o.+(1)
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`)) {
-          val `v₅`: Int = FArrayOps.intAt(s, `i₂`)
-          val `v₆`: Int = `v₅`.+(1)
-          if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-          `out₂`.update(o, `v₆`)
-          o = o.+(1)
-          val `v₇`: Int = `v₅`.*(10)
-          val `v₈`: Int = `v₇`.+(1)
-          if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-          `out₂`.update(o, `v₈`)
-          o = o.+(1)
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case t =>
+        if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      val `v₂`: Int = v.+(1)
+      if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+      `out₂`.update(o, `v₂`)
+      o = o.+(1)
+      val `v₃`: Int = v.*(10)
+      val `v₄`: Int = `v₃`.+(1)
+      if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+      `out₂`.update(o, `v₄`)
+      o = o.+(1)
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(`out₂`.apply(0)) else if (o.==(`out₂`.length)) new IntArr(`out₂`, o) else new IntArr(java.util.Arrays.copyOf(`out₂`, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -1752,104 +1442,52 @@
     val n0: Int = src0.length
     var `out₂`: Array[Int] = new Array[Int](java.lang.Math.max(8, n0))
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = a.apply(i)
-          if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-          `out₂`.update(o, v.*(100))
-          o = o.+(1)
-          {
-            val `y₂`: Int = v.+(1)
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case t =>
+        if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+      `out₂`.update(o, v.*(100))
+      o = o.+(1)
+      val `s₂`: FBase = {
+        val `y₂`: Int = v.+(1)
 
-            {
-              val `$proxy₂`: FArray$package {
-                type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-              } = FArray$package.$asInstanceOf$[FArray$package {
-                type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-              }]
-              val `FArray$package$_this₃`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
-                type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-              }]
+        {
+          val `$proxy₂`: FArray$package {
+            type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+          } = FArray$package.$asInstanceOf$[FArray$package {
+            type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+          }]
+          val `FArray$package$_this₃`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
+            type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
+          }]
 
-              (new IntOne(`y₂`.*(100)).asInstanceOf[FArray[Int]]: FArray[Int])
-            }.$asInstanceOf$[FArray[Int]]
-          }.asInstanceOf[FBase] match {
-            case leaf: IntArr =>
-              val `a₂`: Array[Int] = `leaf₂`.arr
-              val `len₂`: Int = `a₂`.length
-              var `i₂`: Int = 0
-              while (`i₂`.<(`len₂`)) {
-                val `v₂`: Int = `a₂`.apply(`i₂`)
-                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                `out₂`.update(o, `v₂`)
-                o = o.+(1)
-                `i₂` = `i₂`.+(1)
-              }
-            case s =>
-              val `len₃`: Int = s.length
-              var `i₃`: Int = 0
-              while (`i₃`.<(`len₃`)) {
-                val `v₃`: Int = FArrayOps.intAt(s, `i₃`)
-                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                `out₂`.update(o, `v₃`)
-                o = o.+(1)
-                `i₃` = `i₃`.+(1)
-              }
-          }
-          i = i.+(1)
-        }
-      case s =>
-        val `len₄`: Int = `s₂`.length
-        var `i₄`: Int = 0
-        while (`i₄`.<(`len₄`)) {
-          val `v₄`: Int = FArrayOps.intAt(`s₂`, `i₄`)
-          if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-          `out₂`.update(o, `v₄`.*(100))
-          o = o.+(1)
-          {
-            val `y₃`: Int = `v₄`.+(1)
-
-            {
-              val `$proxy₃`: FArray$package {
-                type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-              } = FArray$package.$asInstanceOf$[FArray$package {
-                type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-              }]
-              val `FArray$package$_this₄`: $proxy.type = FArray$package.$asInstanceOf$[FArray$package {
-                type FArray >: [A >: Nothing <: Any] =>> FBase <: [A >: Nothing <: Any] =>> FBase
-              }]
-
-              (new IntOne(`y₃`.*(100)).asInstanceOf[FArray[Int]]: FArray[Int])
-            }.$asInstanceOf$[FArray[Int]]
-          }.asInstanceOf[FBase] match {
-            case leaf: IntArr =>
-              val `a₃`: Array[Int] = `leaf₃`.arr
-              val `len₅`: Int = `a₃`.length
-              var `i₅`: Int = 0
-              while (`i₅`.<(`len₅`)) {
-                val `v₅`: Int = `a₃`.apply(`i₅`)
-                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                `out₂`.update(o, `v₅`)
-                o = o.+(1)
-                `i₅` = `i₅`.+(1)
-              }
-            case s =>
-              val `len₆`: Int = `s₃`.length
-              var `i₆`: Int = 0
-              while (`i₆`.<(`len₆`)) {
-                val `v₆`: Int = FArrayOps.intAt(`s₃`, `i₆`)
-                if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-                `out₂`.update(o, `v₆`)
-                o = o.+(1)
-                `i₆` = `i₆`.+(1)
-              }
-          }
-          `i₄` = `i₄`.+(1)
-        }
+          (new IntOne(`y₂`.*(100)).asInstanceOf[FArray[Int]]: FArray[Int])
+        }.$asInstanceOf$[FArray[Int]]
+      }.asInstanceOf[FBase]
+      val `a₂`: Array[Int] = `s₂` match {
+        case l: IntArr =>
+          (`l₂`.arr: Array[Int])
+        case _ =>
+          null
+      }
+      val `len₂`: Int = `s₂`.length
+      var `i₂`: Int = 0
+      while (`i₂`.<(`len₂`)) {
+        val `v₂`: Int = if (`a₂`.ne(null)) `a₂`.apply(`i₂`) else FArrayOps.intAt(`s₂`, `i₂`)
+        if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+        `out₂`.update(o, `v₂`)
+        o = o.+(1)
+        `i₂` = `i₂`.+(1)
+      }
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(`out₂`.apply(0)) else if (o.==(`out₂`.length)) new IntArr(`out₂`, o) else new IntArr(java.util.Arrays.copyOf(`out₂`, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -1873,30 +1511,22 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = a.apply(i)
-          val `v₂`: Int = v.+(3)
-          val `v₃`: Int = v.+(`v₂`)
-          out.update(o, `v₃`)
-          o = o.+(1)
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`)) {
-          val `v₄`: Int = FArrayOps.intAt(s, `i₂`)
-          val `v₅`: Int = `v₄`.+(3)
-          val `v₆`: Int = `v₄`.+(`v₅`)
-          out.update(o, `v₆`)
-          o = o.+(1)
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case t =>
+        if (`t₂`.length.>=(64)) FArrayOps.materializeInt(`t₂`) else null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      val `v₂`: Int = v.+(3)
+      val `v₃`: Int = v.+(`v₂`)
+      out.update(o, `v₃`)
+      o = o.+(1)
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -1933,66 +1563,40 @@
     val n0: Int = src0.length
     var `out₂`: Array[Int] = new Array[Int](java.lang.Math.max(8, n0))
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = a.apply(i)
-          val `v₂`: Boolean = v.>(0)
-          if (`v₂`) {
-            val `v₃`: Int = v.%(2)
-            val `v₄`: Boolean = `v₃`.==(0)
-            if (`v₄`) {
-              val `v₅`: Int = v.+(1)
-              if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-              `out₂`.update(o, `v₅`)
-              o = o.+(1)
-            } else ()
-            val `v₆`: Int = v.unary_-
-            val `v₇`: Int = `v₆`.%(2)
-            val `v₈`: Boolean = `v₇`.==(0)
-            if (`v₈`) {
-              val `v₉`: Int = v.unary_-
-              val `v₁₀`: Int = `v₉`.+(1)
-              if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-              `out₂`.update(o, `v₁₀`)
-              o = o.+(1)
-            } else ()
-            ()
-          } else ()
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`)) {
-          val `v₁₁`: Int = FArrayOps.intAt(s, `i₂`)
-          val `v₁₂`: Boolean = `v₁₁`.>(0)
-          if (`v₁₂`) {
-            val `v₁₃`: Int = `v₁₁`.%(2)
-            val `v₁₄`: Boolean = `v₁₃`.==(0)
-            if (`v₁₄`) {
-              val `v₁₅`: Int = `v₁₁`.+(1)
-              if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-              `out₂`.update(o, `v₁₅`)
-              o = o.+(1)
-            } else ()
-            val `v₁₆`: Int = `v₁₁`.unary_-
-            val `v₁₇`: Int = `v₁₆`.%(2)
-            val `v₁₈`: Boolean = `v₁₇`.==(0)
-            if (`v₁₈`) {
-              val `v₁₉`: Int = `v₁₁`.unary_-
-              val `v₂₀`: Int = `v₁₉`.+(1)
-              if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-              `out₂`.update(o, `v₂₀`)
-              o = o.+(1)
-            } else ()
-            ()
-          } else ()
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case t =>
+        if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      val `v₂`: Boolean = v.>(0)
+      if (`v₂`) {
+        val `v₃`: Int = v.%(2)
+        val `v₄`: Boolean = `v₃`.==(0)
+        if (`v₄`) {
+          val `v₅`: Int = v.+(1)
+          if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+          `out₂`.update(o, `v₅`)
+          o = o.+(1)
+        } else ()
+        val `v₆`: Int = v.unary_-
+        val `v₇`: Int = `v₆`.%(2)
+        val `v₈`: Boolean = `v₇`.==(0)
+        if (`v₈`) {
+          val `v₉`: Int = v.unary_-
+          val `v₁₀`: Int = `v₉`.+(1)
+          if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+          `out₂`.update(o, `v₁₀`)
+          o = o.+(1)
+        } else ()
+        ()
+      } else ()
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(`out₂`.apply(0)) else if (o.==(`out₂`.length)) new IntArr(`out₂`, o) else new IntArr(java.util.Arrays.copyOf(`out₂`, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -2016,46 +1620,30 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = a.apply(i)
-          val `v₂`: Boolean = v.>(1)
-          if (`v₂`) {
-            val `v₃`: Boolean = v.<(7)
-            if (`v₃`) {
-              val `v₄`: Int = v.%(2)
-              val `v₅`: Boolean = `v₄`.==(0)
-              if (`v₅`) {
-                out.update(o, v)
-                o = o.+(1)
-              } else ()
-            } else ()
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case t =>
+        if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      val `v₂`: Boolean = v.>(1)
+      if (`v₂`) {
+        val `v₃`: Boolean = v.<(7)
+        if (`v₃`) {
+          val `v₄`: Int = v.%(2)
+          val `v₅`: Boolean = `v₄`.==(0)
+          if (`v₅`) {
+            out.update(o, v)
+            o = o.+(1)
           } else ()
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`)) {
-          val `v₆`: Int = FArrayOps.intAt(s, `i₂`)
-          val `v₇`: Boolean = `v₆`.>(1)
-          if (`v₇`) {
-            val `v₈`: Boolean = `v₆`.<(7)
-            if (`v₈`) {
-              val `v₉`: Int = `v₆`.%(2)
-              val `v₁₀`: Boolean = `v₉`.==(0)
-              if (`v₁₀`) {
-                out.update(o, `v₆`)
-                o = o.+(1)
-              } else ()
-            } else ()
-          } else ()
-          `i₂` = `i₂`.+(1)
-        }
+        } else ()
+      } else ()
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -2079,36 +1667,25 @@
     val cap: Int = n0
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len)) {
-          val v: Int = a.apply(i)
-          val `v₂`: Int = v.%(3)
-          val `v₃`: Boolean = `v₂`.==(0)
-          if (`v₃`) {
-            val `v₄`: Int = v.*(7)
-            out.update(o, `v₄`)
-            o = o.+(1)
-          } else ()
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`)) {
-          val `v₅`: Int = FArrayOps.intAt(s, `i₂`)
-          val `v₆`: Int = `v₅`.%(3)
-          val `v₇`: Boolean = `v₆`.==(0)
-          if (`v₇`) {
-            val `v₈`: Int = `v₅`.*(7)
-            out.update(o, `v₈`)
-            o = o.+(1)
-          } else ()
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case t =>
+        if (t.length.>=(64)) FArrayOps.materializeInt(t) else null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      val `v₂`: Int = v.%(3)
+      val `v₃`: Boolean = `v₂`.==(0)
+      if (`v₃`) {
+        val `v₄`: Int = v.*(7)
+        out.update(o, `v₄`)
+        o = o.+(1)
+      } else ()
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -2139,44 +1716,29 @@
     val cap: Int = java.lang.Math.min(n0, lim)
     val out: Array[Int] = new Array[Int](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len).&&(done.unary_!)) {
-          val v: Int = a.apply(i)
-          val `v₂`: Int = v.%(2)
-          val `v₃`: Boolean = `v₂`.==(0)
-          if (`v₃`) {
-            val cv: Int = c
-            if (cv.>=(lim)) done = true else {
-              out.update(o, v)
-              o = o.+(1)
-              c = c.+(1)
-              if (cv.+(1).>=(lim)) done = true else ()
-            }
-          } else ()
-          i = i.+(1)
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case _ =>
+        null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len).&&(done.unary_!)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      val `v₂`: Int = v.%(2)
+      val `v₃`: Boolean = `v₂`.==(0)
+      if (`v₃`) {
+        val cv: Int = c
+        if (cv.>=(lim)) done = true else {
+          out.update(o, v)
+          o = o.+(1)
+          c = c.+(1)
+          if (cv.+(1).>=(lim)) done = true else ()
         }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
-          val `v₄`: Int = FArrayOps.intAt(s, `i₂`)
-          val `v₅`: Int = `v₄`.%(2)
-          val `v₆`: Boolean = `v₅`.==(0)
-          if (`v₆`) {
-            val `cv₂`: Int = c
-            if (`cv₂`.>=(lim)) done = true else {
-              out.update(o, `v₄`)
-              o = o.+(1)
-              c = c.+(1)
-              if (`cv₂`.+(1).>=(lim)) done = true else ()
-            }
-          } else ()
-          `i₂` = `i₂`.+(1)
-        }
+      } else ()
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(out.apply(0)) else if (o.==(cap)) new IntArr(out, o) else new IntArr(java.util.Arrays.copyOf(out, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -2221,70 +1783,42 @@
     var c: Int = 0
     var `out₂`: Array[Int] = new Array[Int](java.lang.Math.max(8, n0))
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len).&&(done.unary_!)) {
-          val v: Int = a.apply(i)
-          val cv: Int = c
-          if (cv.>=(lim)) done = true else {
-            if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-            `out₂`.update(o, v)
-            o = o.+(1)
-            c = c.+(1)
-            if (cv.+(1).>=(lim)) done = true else ()
-          }
-          val `cv₂`: Int = c
-          if (`cv₂`.>=(lim)) done = true else {
-            if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-            `out₂`.update(o, v)
-            o = o.+(1)
-            c = c.+(1)
-            if (`cv₂`.+(1).>=(lim)) done = true else ()
-          }
-          val `cv₃`: Int = c
-          if (`cv₃`.>=(lim)) done = true else {
-            if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-            `out₂`.update(o, v)
-            o = o.+(1)
-            c = c.+(1)
-            if (`cv₃`.+(1).>=(lim)) done = true else ()
-          }
-          i = i.+(1)
-        }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
-          val `v₂`: Int = FArrayOps.intAt(s, `i₂`)
-          val `cv₄`: Int = c
-          if (`cv₄`.>=(lim)) done = true else {
-            if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-            `out₂`.update(o, `v₂`)
-            o = o.+(1)
-            c = c.+(1)
-            if (`cv₄`.+(1).>=(lim)) done = true else ()
-          }
-          val `cv₅`: Int = c
-          if (`cv₅`.>=(lim)) done = true else {
-            if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-            `out₂`.update(o, `v₂`)
-            o = o.+(1)
-            c = c.+(1)
-            if (`cv₅`.+(1).>=(lim)) done = true else ()
-          }
-          val `cv₆`: Int = c
-          if (`cv₆`.>=(lim)) done = true else {
-            if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
-            `out₂`.update(o, `v₂`)
-            o = o.+(1)
-            c = c.+(1)
-            if (`cv₆`.+(1).>=(lim)) done = true else ()
-          }
-          `i₂` = `i₂`.+(1)
-        }
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case _ =>
+        null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len).&&(done.unary_!)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      val cv: Int = c
+      if (cv.>=(lim)) done = true else {
+        if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+        `out₂`.update(o, v)
+        o = o.+(1)
+        c = c.+(1)
+        if (cv.+(1).>=(lim)) done = true else ()
+      }
+      val `cv₂`: Int = c
+      if (`cv₂`.>=(lim)) done = true else {
+        if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+        `out₂`.update(o, v)
+        o = o.+(1)
+        c = c.+(1)
+        if (`cv₂`.+(1).>=(lim)) done = true else ()
+      }
+      val `cv₃`: Int = c
+      if (`cv₃`.>=(lim)) done = true else {
+        if (o.>=(`out₂`.length)) `out₂` = FArrayOps.ensureCapInt(`out₂`, o.+(1)) else ()
+        `out₂`.update(o, v)
+        o = o.+(1)
+        c = c.+(1)
+        if (`cv₃`.+(1).>=(lim)) done = true else ()
+      }
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new IntOne(`out₂`.apply(0)) else if (o.==(`out₂`.length)) new IntArr(`out₂`, o) else new IntArr(java.util.Arrays.copyOf(`out₂`, o), o)
   }.asInstanceOf[FArray[Int]]: FArray[Int])
@@ -2316,48 +1850,31 @@
     val cap: Int = java.lang.Math.min(n0, lim)
     val out: Array[Object] = new Array[Object](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len).&&(done.unary_!)) {
-          val v: Int = a.apply(i)
-          val `v₂`: Int = v.%(2)
-          val `v₃`: Boolean = `v₂`.==(0)
-          if (`v₃`) {
-            val `v₄`: Int = c
-            c = c.+(1)
-            val cv: Int = `c₂`
-            if (cv.>=(lim)) done = true else {
-              out.update(o, new Tuple2$mcII$sp(v, `v₄`).asInstanceOf[Tuple2[Int, Int]].asInstanceOf[Object])
-              o = o.+(1)
-              `c₂` = `c₂`.+(1)
-              if (cv.+(1).>=(lim)) done = true else ()
-            }
-          } else ()
-          i = i.+(1)
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case _ =>
+        null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len).&&(done.unary_!)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      val `v₂`: Int = v.%(2)
+      val `v₃`: Boolean = `v₂`.==(0)
+      if (`v₃`) {
+        val `v₄`: Int = c
+        c = c.+(1)
+        val cv: Int = `c₂`
+        if (cv.>=(lim)) done = true else {
+          out.update(o, new Tuple2$mcII$sp(v, `v₄`).asInstanceOf[Tuple2[Int, Int]].asInstanceOf[Object])
+          o = o.+(1)
+          `c₂` = `c₂`.+(1)
+          if (cv.+(1).>=(lim)) done = true else ()
         }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
-          val `v₅`: Int = FArrayOps.intAt(s, `i₂`)
-          val `v₆`: Int = `v₅`.%(2)
-          val `v₇`: Boolean = `v₆`.==(0)
-          if (`v₇`) {
-            val `v₈`: Int = c
-            c = c.+(1)
-            val `cv₂`: Int = `c₂`
-            if (`cv₂`.>=(lim)) done = true else {
-              out.update(o, new Tuple2$mcII$sp(`v₅`, `v₈`).asInstanceOf[Tuple2[Int, Int]].asInstanceOf[Object])
-              o = o.+(1)
-              `c₂` = `c₂`.+(1)
-              if (`cv₂`.+(1).>=(lim)) done = true else ()
-            }
-          } else ()
-          `i₂` = `i₂`.+(1)
-        }
+      } else ()
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new RefOne(out.apply(0)) else if (o.==(cap)) new RefArr(out, o) else new RefArr(java.util.Arrays.copyOf[Object](out, o), o)
   }.asInstanceOf[FArray[Tuple2[Int, Int]]]: FArray[Tuple2[Int, Int]])
@@ -2389,48 +1906,31 @@
     val cap: Int = java.lang.Math.min(n0, lim)
     val out: Array[Object] = new Array[Object](cap)
     var o: Int = 0
-    src0 match {
-      case leaf: IntArr =>
-        val a: Array[Int] = leaf.arr
-        val len: Int = a.length
-        var i: Int = 0
-        while (i.<(len).&&(done.unary_!)) {
-          val v: Int = a.apply(i)
-          val `v₂`: Int = c
-          c = c.+(1)
-          val `v₃`: Int = v.%(2)
-          val `v₄`: Boolean = `v₃`.==(0)
-          if (`v₄`) {
-            val cv: Int = `c₂`
-            if (cv.>=(lim)) done = true else {
-              out.update(o, new Tuple2$mcII$sp(v, `v₂`).asInstanceOf[Tuple2[Int, Int]].asInstanceOf[Object])
-              o = o.+(1)
-              `c₂` = `c₂`.+(1)
-              if (cv.+(1).>=(lim)) done = true else ()
-            }
-          } else ()
-          i = i.+(1)
+    val s: FBase = src0
+    val a: Array[Int] = s match {
+      case l: IntArr =>
+        (l.arr: Array[Int])
+      case _ =>
+        null
+    }
+    val len: Int = s.length
+    var i: Int = 0
+    while (i.<(len).&&(done.unary_!)) {
+      val v: Int = if (a.ne(null)) a.apply(i) else FArrayOps.intAt(s, i)
+      val `v₂`: Int = c
+      c = c.+(1)
+      val `v₃`: Int = v.%(2)
+      val `v₄`: Boolean = `v₃`.==(0)
+      if (`v₄`) {
+        val cv: Int = `c₂`
+        if (cv.>=(lim)) done = true else {
+          out.update(o, new Tuple2$mcII$sp(v, `v₂`).asInstanceOf[Tuple2[Int, Int]].asInstanceOf[Object])
+          o = o.+(1)
+          `c₂` = `c₂`.+(1)
+          if (cv.+(1).>=(lim)) done = true else ()
         }
-      case s =>
-        val `len₂`: Int = s.length
-        var `i₂`: Int = 0
-        while (`i₂`.<(`len₂`).&&(done.unary_!)) {
-          val `v₅`: Int = FArrayOps.intAt(s, `i₂`)
-          val `v₆`: Int = c
-          c = c.+(1)
-          val `v₇`: Int = `v₅`.%(2)
-          val `v₈`: Boolean = `v₇`.==(0)
-          if (`v₈`) {
-            val `cv₂`: Int = `c₂`
-            if (`cv₂`.>=(lim)) done = true else {
-              out.update(o, new Tuple2$mcII$sp(`v₅`, `v₆`).asInstanceOf[Tuple2[Int, Int]].asInstanceOf[Object])
-              o = o.+(1)
-              `c₂` = `c₂`.+(1)
-              if (`cv₂`.+(1).>=(lim)) done = true else ()
-            }
-          } else ()
-          `i₂` = `i₂`.+(1)
-        }
+      } else ()
+      i = i.+(1)
     }
     if (o.==(0)) (Empty.INSTANCE: FBase) else if (o.==(1)) new RefOne(out.apply(0)) else if (o.==(cap)) new RefArr(out, o) else new RefArr(java.util.Arrays.copyOf[Object](out, o), o)
   }.asInstanceOf[FArray[Tuple2[Int, Int]]]: FArray[Tuple2[Int, Int]])

--- a/tests/src/scala/farray/FarrayTest.scala
+++ b/tests/src/scala/farray/FarrayTest.scala
@@ -702,6 +702,20 @@ class FListTest:
     org.junit.Assert.assertEquals(List(4L, 8L), FArray(1L, 2L, 3L, 4L).fuse.filter(_ % 2L == 0L).map(_ * 2L).run.toList)
   @Test def test_fuse_tree_source: Unit = // non-leaf source (Concat) exercises the <kind>At fallback
     org.junit.Assert.assertEquals(List(20, 40, 60), (FArray(1, 2, 3) ++ FArray(4, 5, 6)).fuse.filter(_ % 2 == 0).map(_ * 10).run.toList)
+  // ---- slack leaves: groupBy values wrap the growable buffer, so arr.length > length. The fused loop
+  //      must run to the LOGICAL length, not the backing array's, or it processes garbage slack slots. ----
+  @Test def test_fuse_slack_leaf_map: Unit =
+    val odds = FArray(1, 2, 3, 4, 5).groupBy(_ % 2)(1) // FArray(1, 3, 5) over a cap-4 buffer
+    org.junit.Assert.assertEquals(List(2, 4, 6), odds.fuse.map(_ + 1).run.toList)
+  @Test def test_fuse_slack_leaf_count: Unit =
+    val odds = FArray(1, 2, 3, 4, 5).groupBy(_ % 2)(1)
+    org.junit.Assert.assertEquals(3, odds.fuse.count(_ => true))
+  @Test def test_fuse_slack_leaf_ref: Unit =
+    val short = FArray("a", "bb", "cc", "d", "e").groupBy(_.length)(1) // FArray("a", "d", "e"), slack slots are null
+    org.junit.Assert.assertEquals(List("A", "D", "E"), short.fuse.map(_.toUpperCase).run.toList)
+  @Test def test_fuse_slack_leaf_flatMap_inner: Unit = // slack leaf as the INNER of a fused flatMap
+    val odds = FArray(1, 2, 3, 4, 5).groupBy(_ % 2)(1)
+    org.junit.Assert.assertEquals(List(1, 3, 5, 1, 3, 5), FArray(0, 1).fuse.flatMap(_ => odds).run.toList)
 
   // ---- take / drop (positional) ----
   private val r10 = FArray.tabulate(10)(i => i) // 0..9


### PR DESCRIPTION
## What

`elementLoop` emitted the whole fused body **twice** (peeled `${K}Arr` fast-path arm + `<kind>At` fallback arm), duplicated across 9 near-identical kind cases in the macro. It's now one generic skeleton: bind the read source once —

```scala
val a: Array[Int] = s match {
  case l: IntArr => l.arr
  case t         => if (t.length >= 64) FArrayOps.materializeInt(t) else null  // outer + no done-flag only
}
```

— then a single fused body reading `if (a ne null) a(i) else intAt(s, i)`, with the loop bound on the **logical** length. Snapshot expansions literally halved (net −693 lines in the PR).

## Live bug fixed

The old leaf arm looped to `a.length`, but `${K}Arr` leaves carry slack (`groupBy`/`collect`/`partitionMap` values wrap the growable buffer, `arr.length > length`). Fusing over a groupBy value threw AIOOBE on map sinks, NPE'd on Ref null slack slots, over-counted, and spliced garbage as a flatMap inner. Four new parity tests (`test_fuse_slack_leaf_*`) cover it.

## Measured (isolated stash A/B, `-f1` + `-f2` confirms, GraalVM CE 25 + HotSpot C2 temurin:25)

New gate bench `FuseSourceShapeBench` — note every pre-existing fused-flatMap bench uses *literal* inners, which the macro splats without ever entering `elementLoop`.

- **Leaf paths tie**: leafFold 1.00–1.08×, leafMapFilterRun 1.04–1.06× (both JITs). The null-check on a loop-invariant local folds/unswitches — it is not a call boundary.
- **Fresh flatMap-inner EA preserved**: flatMapFreshLeafInner 1.01–1.04×, alloc byte-identical on C2. (What breaks scalar replacement is routing reads through a shared consumer call — still avoided.)
- **Halving fused-body bytecode is a real win on long pipelines**: deadZipFused **1.88×** (`-f2` confirmed), deadColFused ~2×, survivorFused ~1.5×, IntAllOpsBench.farrayFused 1.2–1.3× (Graal).
- **Tree fallback goes from 17× behind the leaf path to a win**: full-traversal sinks flatten the tree once (DFS arraycopy runs) instead of per-element `intAt` tree walks — treeFold **8.5–11×**, treeMapFilterRun **2.7–3.2×**, at the cost of one flat copy. Guards: short-circuit sinks never pre-flatten (treeExistsEarly stays at ~250M ops/s), flatMap inners never re-materialize per outer element, One/tiny nodes excluded (≥64).
- **Accepted niche cost**: fused flatMap over a *shared tiny tree* inner is 0.80× on C2 only (Graal 1.03–1.13×). Materializing tiny inners instead was measured worse (828 vs 1015 ops/s, 15MB/op) and rejected; eager flatMap's `${K}FlatMap` node serves that shape.

## Tests

457/457 green (`bleep test tests`), including the 4 new slack-leaf tests and the refreshed expansion snapshots.

Scorecard sweep (`scripts/bench-run.sh`) deferred — will re-measure and check in the refreshed docs report separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)