### PR TITLE
Docs: persona-readthrough follow-up (dedup, consolidate, thread-safety)

### DIFF
--- a/site/docs/chains.mdx
+++ b/site/docs/chains.mdx
@@ -1,6 +1,6 @@
 ---
-title: Motivation
-sidebar_label: Motivation
+title: Why FArray
+sidebar_label: Why FArray
 description: "Eager FArray, no .fuse anywhere, already beats List, Vector, IArray and the Chunks. Single ops tie a raw array; chaining is where the model compounds, shown Int beside String."
 ---
 
@@ -154,8 +154,8 @@ strongest field; fusion is the ceiling.
 
 <Related
   links={[
-    { to: "/fusion/benchmarks", label: "The fused receipts", desc: "The same argument, one loop deeper." },
-    { to: "/benchmarks/farray", label: "The scoreboard", desc: "Every op at every size, boiled to one number." },
-    { to: "/benchmarks/farray", label: "The full suite", desc: "All charts, including every chain here." },
+    { to: "/fusion/benchmarks", label: "Why fusion", desc: "The same argument, one loop deeper." },
+    { to: "/benchmarks/farray", label: "The full scoreboard", desc: "Every op at every size, wins and losses, every chart behind the numbers here." },
+    { to: "/semantics", label: "Sharp edges", desc: "The contracts that differ from the standard library." },
   ]}
 />

--- a/site/docs/chains.mdx
+++ b/site/docs/chains.mdx
@@ -8,7 +8,6 @@ import Link from "@docusaurus/Link";
 import BenchPair from "@site/src/components/BenchPair";
 import BenchChart from "@site/src/components/BenchChart";
 import ChainScore from "@site/src/components/ChainScore";
-import Related from "@site/src/components/Related";
 
 {/* This page is eager-only by construction. The fused/lazy pipelines belong with the fused
     comparison, not here: java.util.stream (a lazy fused pipeline) and FArray's own .fuse (the
@@ -153,11 +152,3 @@ There is one speed above this: handing the whole chain to the compiler.{" "}
 <Link to="/fusion">Fusion</Link> takes these same pipelines and emits a single loop; the 14-stage
 version runs ~15× past even FArray's own eager chains. The eager ops above are already the
 strongest field; fusion is the ceiling.
-
-<Related
-  links={[
-    { to: "/fusion/benchmarks", label: "Why fusion", desc: "The same argument, one loop deeper." },
-    { to: "/benchmarks/farray", label: "The full scoreboard", desc: "Every op at every size, wins and losses, every chart behind the numbers here." },
-    { to: "/semantics", label: "Sharp edges", desc: "The contracts that differ from the standard library." },
-  ]}
-/>

--- a/site/docs/chains.mdx
+++ b/site/docs/chains.mdx
@@ -15,6 +15,8 @@ import Related from "@site/src/components/Related";
     `farrayFused` bar, e.g. on the cold-pipeline chart). Every chart drops them via ignore={fused}. */}
 export const fused = ["javastream", "farrayFused"];
 
+<p className="page__eyebrow">what FArray buys</p>
+
 <p className="lede">
   The introduction led with fusion, FArray's headline trick, which has{" "}
   <Link to="/fusion">its own section</Link>. This page is the plain library: no <code>.fuse</code>

--- a/site/docs/design/combinators.mdx
+++ b/site/docs/design/combinators.mdx
@@ -21,7 +21,7 @@ import Related from "@site/src/components/Related";
 
 That laziness is the trade. A bare array would be a hair quicker at a single indexed read (one
 type-check that `int[]` doesn't carry), but it can't compare or print itself:
-`IArray(1, 2, 3).toString` (IArray being Scala's immutable view of a raw array) is `[I@5a07e868`
+`IArray(1, 2, 3).toString` is `[I@5a07e868`
 and `==` is identity. FArray wraps the array in an object,
 so it gives that hair back and gets value `equals`, `hashCode` and `toString`, plus a collection you
 can assemble any way you please, in constant time, paying for a flat array only when you ask for one.
@@ -46,8 +46,7 @@ that is array-speed. The flat array is the preferred shape, and computing restor
 />
 
 One consequence gets [a page of its own](../operations/list-parity.mdx): driven as a
-literal cons-list, FArray keeps pace with `List` (the immutable cons list, no relation to
-`java.util.List`) at `List`'s own game.
+literal cons-list, FArray keeps pace with `List` at `List`'s own game.
 
 Two more ops belong to the O(1) family and rarely get counted: `updated(i, x)` is an `Updated`
 node (a view of the original with one slot overridden, no copy of the other n−1 elements) and

--- a/site/docs/design/combinators.mdx
+++ b/site/docs/design/combinators.mdx
@@ -7,7 +7,6 @@ description: "The cost model: structural ops build lazy O(1) nodes; elementwise 
 import BenchChart from "@site/src/components/BenchChart";
 import BenchPair from "@site/src/components/BenchPair";
 import Complexity from "@site/src/components/Complexity";
-import Related from "@site/src/components/Related";
 
 <p className="lede">
   The whole cost model hangs off the split between the flavours. The{" "}
@@ -65,11 +64,4 @@ materialized array, with a run-detecting mergesort, no boxed indices, and no `Or
   int="SortIntBenchmark"
   str="SortStrBenchmark"
   caption="sortBy / sortWith / sorted, Int beside String. On Int the unboxed mergesort runs ~2–2.3× past IArray on sortBy/sortWith and buries the boxing collections (sorted is a dead heat with IArray; both bottom out in the same array sort). On String there's no unboxing to win, so sortWith and sorted tie IArray, but sortBy still runs ~4–5× past the whole field, because FArray sorts cached keys instead of re-deriving them per comparison."
-/>
-
-<Related
-  links={[
-    { to: "/operations/map", label: "How map stays unboxed", desc: "Inside the elementwise machinery the cost model rests on." },
-    { to: "/benchmarks/farray", label: "FArray benchmarks", desc: "Every structural and elementwise op, at every size." },
-  ]}
 />

--- a/site/docs/design/scala-surface.mdx
+++ b/site/docs/design/scala-surface.mdx
@@ -26,7 +26,7 @@ The **structural** ones (`reverse`, `++`) just call the matching `FBase` method.
 already *is* its core, that's a direct call into the lazy O(1) node-builders from
 [the Java core](./java-core.mdx), with no specialization involved.
 
-The **elementwise** ones are marked `inline` (a Scala 3 compiler guarantee, not a JIT hint), and
+The **elementwise** ones are marked `inline`, and
 they take their lambda `inline` too:
 `inline def map[B](inline f: A => B)`. At every concrete call site the method body is spliced in, your
 lambda with it, and the whole thing forwards to a generated `…Impl`. That forward is where the

--- a/site/docs/fset.mdx
+++ b/site/docs/fset.mdx
@@ -45,8 +45,7 @@ export function FinitenessTable() {
 
 <p className="lede">
   An immutable, unboxed set on the FArray playbook (a generated Java core, per-kind specialization,{" "}
-  <code>inline</code> dispatch, where Scala's <code>inline</code> is a compiler guarantee rather
-  than a JIT hint), plus one contrarian bet. Every immutable set on the JVM pays
+  <code>inline</code> dispatch), plus one contrarian bet. Every immutable set on the JVM pays
   the persistent-trie tax to make single-element updates cheap. FSet refuses to pay it, and builds an
   immutable set the way you actually use one: frozen flat leaves, queried hard, combined
   lazily. Everything on this page is a consequence of that one bet. And as everywhere on this site:

--- a/site/docs/fset.mdx
+++ b/site/docs/fset.mdx
@@ -9,7 +9,6 @@ import GeneratedCode from "@site/src/components/GeneratedCode";
 import BenchChart from "@site/src/components/BenchChart";
 import BenchPair from "@site/src/components/BenchPair";
 import Scorecard from "@site/src/components/Scorecard";
-import Related from "@site/src/components/Related";
 
 export const FINITENESS = [
   { op: "a ∪ b", finite: "both finite", note: "infinite if either side is" },
@@ -387,10 +386,3 @@ multiples.
 
 The full record is on the [FSet benchmarks page](./benchmarks/fset.mdx): every chart, every
 competitor, with the exact `@Benchmark` source behind each card.
-
-<Related
-  links={[
-    { to: "/benchmarks/fset", label: "FSet benchmarks", desc: "The complete scorecard: every chart, every competitor." },
-    { to: "/design/java-core", label: "The FArray core", desc: "The generated-Java playbook FSet is built on." },
-  ]}
-/>

--- a/site/docs/fusion/benchmarks.mdx
+++ b/site/docs/fusion/benchmarks.mdx
@@ -10,7 +10,6 @@ import Snippet from "@site/src/components/Snippet";
 import SideBySide from "@site/src/components/SideBySide";
 import BenchChart from "@site/src/components/BenchChart";
 import BenchPair from "@site/src/components/BenchPair";
-import Related from "@site/src/components/Related";
 
 <p className="page__eyebrow">what fusion buys</p>
 
@@ -90,10 +89,3 @@ The byte-source numbers live with their scanners and rivals on{" "}
 <Link to="/fusion/json">the JSON integration page</Link>. The headline: 1.6× past jsoniter-scala's
 hand-written reader loop at ~1 B/op, 4–9× past the AST parsers, and 2.5× on selective queries where
 records are abandoned mid-scan.
-
-<Related
-  links={[
-    { to: "/benchmarks/farray", label: "The full FArray suite", desc: "Every op at every size, wins and losses alike." },
-    { to: "/fusion", label: "Back to first principles", desc: "Why these numbers don't depend on the call site." },
-  ]}
-/>

--- a/site/docs/fusion/benchmarks.mdx
+++ b/site/docs/fusion/benchmarks.mdx
@@ -1,6 +1,6 @@
 ---
-title: Motivation
-sidebar_label: Motivation
+title: Why fusion
+sidebar_label: Why fusion
 description: "What fusion buys, measured first: the fused pipeline warm, cold, streaming, against java.util.stream, and on a second long chain — every bar hoverable, every @Benchmark source one click away."
 hide_table_of_contents: true
 ---
@@ -66,13 +66,10 @@ ahead:
 
 ## Streaming: constant memory without the streaming tax
 
-The chunk-granular <Link to="/fusion/sources">source model</Link>, against the JVM's usual ways of
-processing data you don't want in memory:
-
-<BenchChart
-  cls="StreamPipelineBenchmark"
-  caption="filter → map → sum over a lazily GENERATED sequence (vs Iterator, LazyList (Scala's lazy linked list), fs2.Stream) and over an InputStream of lines (vs scala.io.Source and a hand-rolled BufferedReader loop). Chunks amortize the pull; the per-element cost is the fused loop."
-/>
+The same fused loop runs over data too big for the heap — a generated sequence, or a file's lines,
+folded without holding either in memory, at no per-element streaming tax. The chart, against
+`Iterator`, `LazyList`, `fs2.Stream` and a hand-rolled `BufferedReader`, lives with the{" "}
+<Link to="/fusion/sources#streaming-measured">source model</Link> that makes it work.
 
 ## A second pipeline, a different stage mix
 

--- a/site/docs/fusion/benchmarks.mdx
+++ b/site/docs/fusion/benchmarks.mdx
@@ -12,7 +12,7 @@ import BenchChart from "@site/src/components/BenchChart";
 import BenchPair from "@site/src/components/BenchPair";
 import Related from "@site/src/components/Related";
 
-<p className="page__eyebrow">motivation</p>
+<p className="page__eyebrow">what fusion buys</p>
 
 <p className="lede">
   Before the how, the what. This is what fusion buys, measured — every bar a JMH sweep you can hover,

--- a/site/docs/fusion/farray.mdx
+++ b/site/docs/fusion/farray.mdx
@@ -6,7 +6,6 @@ description: "The practical guide: when to reach for .fuse, the recipes that rep
 
 import Link from "@docusaurus/Link";
 import Snippet from "@site/src/components/Snippet";
-import BenchChart from "@site/src/components/BenchChart";
 import Related from "@site/src/components/Related";
 
 <p className="page__eyebrow">putting it to work</p>
@@ -35,18 +34,14 @@ import Related from "@site/src/components/Related";
   <li>
     <strong>Cold and warm alike.</strong> The specialization is in the bytecode, so fused pipelines
     lead from the first uncompiled invocation (CLI tools, lambdas, startup paths), and the lead
-    widens as the JIT warms the loop.
+    widens as the JIT warms the loop — measured cold on the{" "}
+    <Link to="/fusion/benchmarks">Motivation page</Link>, ~3.8× ahead before anything compiles.
   </li>
   <li>
     <strong>Not worth it:</strong> a single <code>map</code> or <code>filter</code>. The eager op is
     already one specialized loop; there is nothing for fusion to remove.
   </li>
 </ul>
-
-<BenchChart
-  cls="ColdPipelineIntBenchmark"
-  caption="The 14-stage pipeline measured COLD: SingleShotTime, zero warmup, one uncompiled invocation at 100k elements. Fused FArray is ~3.8× past List and IArray before the JIT has compiled anything: the speed is in the bytecode, not in the warmup. Warm, the same pipeline's lead opens to ~36× (see the benchmarks page)."
-/>
 
 ## The recipes
 
@@ -117,7 +112,7 @@ callers see only the resulting `FArray`.
 
 <Related
   links={[
-    { to: "/fusion/benchmarks", label: "Next: The receipts", desc: "Warm, cold, streaming, and the chain that used to collapse." },
+    { to: "/fusion/benchmarks", label: "Fusion, measured", desc: "Warm, cold, streaming, against java.util.stream, and a second long pipeline." },
     { to: "/fusion/json", label: "The JSON integration", desc: "The same engine pointed at raw bytes." },
     { to: "/benchmarks/farray", label: "The FArray scoreboard", desc: "Where the eager ops already stand." },
   ]}

--- a/site/docs/fusion/farray.mdx
+++ b/site/docs/fusion/farray.mdx
@@ -6,7 +6,6 @@ description: "The practical guide: when to reach for .fuse, the recipes that rep
 
 import Link from "@docusaurus/Link";
 import Snippet from "@site/src/components/Snippet";
-import Related from "@site/src/components/Related";
 
 <p className="page__eyebrow">putting it to work</p>
 
@@ -109,11 +108,3 @@ callers see only the resulting `FArray`.
     call it in the chain — it splices in and fuses just as if written in place.
   </li>
 </ul>
-
-<Related
-  links={[
-    { to: "/fusion/benchmarks", label: "Fusion, measured", desc: "Warm, cold, streaming, against java.util.stream, and a second long pipeline." },
-    { to: "/fusion/json", label: "The JSON integration", desc: "The same engine pointed at raw bytes." },
-    { to: "/benchmarks/farray", label: "The FArray scoreboard", desc: "Where the eager ops already stand." },
-  ]}
-/>

--- a/site/docs/fusion/farray.mdx
+++ b/site/docs/fusion/farray.mdx
@@ -35,7 +35,7 @@ import Related from "@site/src/components/Related";
     <strong>Cold and warm alike.</strong> The specialization is in the bytecode, so fused pipelines
     lead from the first uncompiled invocation (CLI tools, lambdas, startup paths), and the lead
     widens as the JIT warms the loop — measured cold on the{" "}
-    <Link to="/fusion/benchmarks">Motivation page</Link>, ~3.8× ahead before anything compiles.
+    <Link to="/fusion/benchmarks">Why fusion page</Link>, ~3.8× ahead before anything compiles.
   </li>
   <li>
     <strong>Not worth it:</strong> a single <code>map</code> or <code>filter</code>. The eager op is

--- a/site/docs/fusion/index.mdx
+++ b/site/docs/fusion/index.mdx
@@ -6,7 +6,6 @@ description: "Why JVM pipelines are slow, what compiling them at compile time bu
 
 import Link from "@docusaurus/Link";
 import Snippet from "@site/src/components/Snippet";
-import Related from "@site/src/components/Related";
 
 export function FuseEx({ src, gen }) {
   return (
@@ -153,11 +152,3 @@ Four rules:
     stage. There is no fallback path that silently runs slow.
   </li>
 </ul>
-
-<Related
-  links={[
-    { to: "/fusion/sources", label: "Start: Sources", desc: "Where pipelines begin: arrays, chunk streams, raw bytes." },
-    { to: "/fusion/benchmarks", label: "The receipts", desc: "Warm, cold, streaming, and against the field." },
-    { to: "/", label: "The FArray story", desc: "The collection library the engine grew out of." },
-  ]}
-/>

--- a/site/docs/fusion/integrating.mdx
+++ b/site/docs/fusion/integrating.mdx
@@ -7,7 +7,6 @@ description: "What the engine actually is (a loop assembler over columns), why o
 import Link from "@docusaurus/Link";
 import Snippet from "@site/src/components/Snippet";
 import GeneratedCode from "@site/src/components/GeneratedCode";
-import Related from "@site/src/components/Related";
 
 <p className="page__eyebrow">for library authors</p>
 
@@ -155,11 +154,3 @@ The boundaries, stated as plainly as the wins:
   a byte source they force every field live and rebuild the record per surviving element,
   projection pushdown is off. `sum`/`fold`/`count`/`avg`/`agg` and the key-projecting extremums
   decode only what they touch. The plan string makes this visible (`rebuildsRecord=true`).
-
-<Related
-  links={[
-    { to: "/fusion/json", label: "The worked example", desc: "The NDJSON integration running real queries, with scanners and rivals." },
-    { to: "/fusion/optimizer", label: "The optimizer", desc: "The column machinery this page's model rests on." },
-    { to: "/fusion/terminals", label: "The terminals", desc: "What the capability traits actually grant." },
-  ]}
-/>

--- a/site/docs/fusion/json.mdx
+++ b/site/docs/fusion/json.mdx
@@ -6,7 +6,6 @@ description: "A JSON decoder plugged into the fusion engine as a typeclass insta
 
 import Link from "@docusaurus/Link";
 import Snippet from "@site/src/components/Snippet";
-import Related from "@site/src/components/Related";
 
 export function BenchTable({ bench }) {
   return (
@@ -238,11 +237,3 @@ call site, and an unsupported *terminal* is not a member. No silent fallback exi
 
 Scanners are the verbatim post-typer expansion, regenerated to current codegen and checked into
 `tests/snapshots/`. Numbers are JMH (`-prof gc`) from `benchmarks/JsonProjectionBenchmark`.
-
-<Related
-  links={[
-    { to: "/fusion/benchmarks", label: "Next: The receipts", desc: "The fusion benchmarks, end to end." },
-    { to: "/fusion/integrating", label: "Integrating with fusion", desc: "The plug-in contract this page is a worked example of." },
-    { to: "/fusion/optimizer", label: "The optimizer", desc: "The column analysis, over tuples instead of bytes." },
-  ]}
-/>

--- a/site/docs/fusion/optimizer.mdx
+++ b/site/docs/fusion/optimizer.mdx
@@ -5,7 +5,6 @@ description: "The shared brain: products decomposed into independent columns, de
 ---
 
 import Snippet from "@site/src/components/Snippet";
-import Related from "@site/src/components/Related";
 
 export function FuseEx({ src, gen }) {
   return (
@@ -72,11 +71,3 @@ the entire product per element just to read one field.
 
 Emitted blocks are the verbatim post-typer expansion (`FuseDebug.show`), regenerated to current
 codegen and checked into `tests/snapshots/`; they are shown, not executed.
-
-<Related
-  links={[
-    { to: "/fusion/farray", label: "Using .fuse", desc: "The practical guide: when to reach for it, the recipes, the gotchas." },
-    { to: "/fusion/json", label: "The JSON experiment", desc: "The same optimizer, unchanged, applied to raw bytes." },
-    { to: "/operations/map", label: "How map stays unboxed", desc: "The eager gear below fusion, and why they split." },
-  ]}
-/>

--- a/site/docs/fusion/optimizer.mdx
+++ b/site/docs/fusion/optimizer.mdx
@@ -75,7 +75,7 @@ codegen and checked into `tests/snapshots/`; they are shown, not executed.
 
 <Related
   links={[
-    { to: "/fusion", label: "Using .fuse", desc: "The user guide: every stage and terminal, with their loops." },
+    { to: "/fusion/farray", label: "Using .fuse", desc: "The practical guide: when to reach for it, the recipes, the gotchas." },
     { to: "/fusion/json", label: "The JSON experiment", desc: "The same optimizer, unchanged, applied to raw bytes." },
     { to: "/operations/map", label: "How map stays unboxed", desc: "The eager gear below fusion, and why they split." },
   ]}

--- a/site/docs/fusion/sources.mdx
+++ b/site/docs/fusion/sources.mdx
@@ -7,7 +7,6 @@ description: "Where pipelines begin: in-memory arrays, chunk streams in constant
 import Link from "@docusaurus/Link";
 import Snippet from "@site/src/components/Snippet";
 import BenchChart from "@site/src/components/BenchChart";
-import Related from "@site/src/components/Related";
 
 <p className="page__eyebrow">the source</p>
 
@@ -74,10 +73,3 @@ the machine: stages are shape-generic, but{" "}
 by a typeclass (an interface implementation the compiler selects by type, like a ServiceLoader
 resolved at compile time). It has no runtime cost; it exists so that an unsupported operation is a
 compile error rather than a runtime surprise.
-
-<Related
-  links={[
-    { to: "/fusion/stages", label: "Next: Stages", desc: "The vocabulary: markers that cost nothing." },
-    { to: "/fusion/json", label: "Byte sources in full", desc: "ByteRecordSource and the NDJSON integration, one file." },
-  ]}
-/>

--- a/site/docs/fusion/stages.mdx
+++ b/site/docs/fusion/stages.mdx
@@ -6,7 +6,6 @@ description: "The pipeline vocabulary: markers that cost nothing, the algebraic 
 
 import Link from "@docusaurus/Link";
 import Snippet from "@site/src/components/Snippet";
-import Related from "@site/src/components/Related";
 
 export function FuseEx({ src, gen }) {
   return (
@@ -151,10 +150,3 @@ a million elements. And when a `map` builds a product whose columns a later `fil
 reads, the unread columns are computed only for survivors; that analysis belongs to{" "}
 <Link to="/fusion/optimizer">the optimizer</Link>. For pure lambdas the results are identical to the
 strict semantics; side-effecting lambdas can observe the difference.
-
-<Related
-  links={[
-    { to: "/fusion/terminals", label: "Next: Terminals", desc: "The call that ends the chain is the compiler invocation." },
-    { to: "/fusion/optimizer", label: "The optimizer", desc: "Columns, dead-column elimination, compute-for-survivors." },
-  ]}
-/>

--- a/site/docs/fusion/terminals.mdx
+++ b/site/docs/fusion/terminals.mdx
@@ -6,7 +6,6 @@ description: "The call that ends the chain is the compiler invocation: the termi
 
 import Link from "@docusaurus/Link";
 import Snippet from "@site/src/components/Snippet";
-import Related from "@site/src/components/Related";
 
 export function FuseEx({ src, gen }) {
   return (
@@ -104,10 +103,3 @@ The ranking family exists because "top ten by score" should not cost a sort: `to
 a bounded size-*n* heap inside the pass (O(N log n) time, O(n) memory, best-first):
 
 <FuseEx src="fuse-src-guide-topn" gen="fuse-guide-topn" />
-
-<Related
-  links={[
-    { to: "/fusion/optimizer", label: "Next: The optimizer", desc: "Columns, DCE, compute-for-survivors: the shared brain." },
-    { to: "/fusion/integrating", label: "Integrating", desc: "Where terminals come from: shapes, lowerings, and the plug-in contract." },
-  ]}
-/>

--- a/site/docs/index.mdx
+++ b/site/docs/index.mdx
@@ -10,7 +10,6 @@ hide_title: true
 
 import SideBySide from "@site/src/components/SideBySide";
 import GeneratedCode from "@site/src/components/GeneratedCode";
-import Related from "@site/src/components/Related";
 import Ladder from "@site/src/components/Ladder";
 import Scorecard from "@site/src/components/Scorecard";
 import { FusionDiagram } from "@site/src/components/Diagrams";
@@ -149,11 +148,3 @@ every size, boiled down per structure, losses included; [the benchmarks page](./
 has every chart behind it.
 
 <Scorecard />
-
-<Related
-  links={[
-    { to: "/chains", label: "Why FArray", desc: "Eager FArray, no .fuse: it already beats the field, and chaining is where it pulls away." },
-    { to: "/fusion", label: "The fusion engine", desc: "Sources, stages, terminals, the optimizer, and the receipts." },
-    { to: "/benchmarks/farray", label: "FArray benchmarks", desc: "The complete scorecard: every op, every size, every rival." },
-  ]}
-/>

--- a/site/docs/index.mdx
+++ b/site/docs/index.mdx
@@ -66,9 +66,10 @@ commits later:
     nothing between stages.
   </li>
   <li>
-    <strong>Claude is why.</strong> The redesign was years of evenings I didn't have. Most of the
-    implementation was written by the model from a human design; every optimization was measured and
-    several were reverted. A note on how that worked is in the <a href="./use">M1 status</a>.
+    <strong>Claude is why.</strong> Most of the implementation was written by the model from a human
+    design, under review and a test gate: every operation parity-checked against <code>List</code>,
+    every optimization measured, several reverted. That is what made the redesign — years of evenings
+    I never had — tractable at all. How it worked is in the <a href="./use">M1 status</a>.
   </li>
 </ul>
 
@@ -151,7 +152,7 @@ has every chart behind it.
 
 <Related
   links={[
-    { to: "/chains", label: "Motivation", desc: "Eager FArray, no .fuse: it already beats the field, and chaining is where it pulls away." },
+    { to: "/chains", label: "Why FArray", desc: "Eager FArray, no .fuse: it already beats the field, and chaining is where it pulls away." },
     { to: "/fusion", label: "The fusion engine", desc: "Sources, stages, terminals, the optimizer, and the receipts." },
     { to: "/benchmarks/farray", label: "FArray benchmarks", desc: "The complete scorecard: every op, every size, every rival." },
   ]}

--- a/site/docs/index.mdx
+++ b/site/docs/index.mdx
@@ -131,7 +131,8 @@ Scala 3 is a guarantee performed by the compiler, not a hint to the JIT: the op'
 lambda land in your method, with the unboxing fixed in the signature. That last part matters: the rivals that tie us on a
 single op lose that tie as the surrounding method grows, because their unboxing depends on the JIT's
 inlining budget and ours doesn't. No fusion involved, and it already beats the field.
-[Fast without fusion](./chains.mdx) is the whole eager argument, scored across the suite.
+The whole eager argument, scored across every chained benchmark in the suite, is [the next
+page](./chains.mdx).
 
 **The word.** Java Streams, Scala views and iterators all fuse at runtime and pay for it per
 element, per stage. `.fuse` does it at compile time, and what it emits is the `while` loop you would have
@@ -150,7 +151,7 @@ has every chart behind it.
 
 <Related
   links={[
-    { to: "/chains", label: "Fast without fusion", desc: "Eager FArray, no .fuse: it already beats the field, and chaining is where it pulls away." },
+    { to: "/chains", label: "Motivation", desc: "Eager FArray, no .fuse: it already beats the field, and chaining is where it pulls away." },
     { to: "/fusion", label: "The fusion engine", desc: "Sources, stages, terminals, the optimizer, and the receipts." },
     { to: "/benchmarks/farray", label: "FArray benchmarks", desc: "The complete scorecard: every op, every size, every rival." },
   ]}

--- a/site/docs/operations/builder.mdx
+++ b/site/docs/operations/builder.mdx
@@ -6,7 +6,6 @@ description: "FBuilder[A]: accumulate elements one at a time with zero boxing, b
 
 import Link from "@docusaurus/Link";
 import BenchPair from "@site/src/components/BenchPair";
-import Related from "@site/src/components/Related";
 
 <p className="lede">
   Sometimes you don't have the elements up front: you push them one at a time and want an{" "}
@@ -120,11 +119,3 @@ check), so the gap isn't the cast or an allocation (both ruled out by measuremen
 compiles stdlib's ubiquitous `addOne` almost to a bare loop, and our leaner `RefGroup.add` doesn't
 get the same field-hoisting. It's more than repaid by the O(1) `result()` (ArrayBuffer pays O(n) to
 finalize), so the end-to-end number is a win.
-
-<Related
-  links={[
-    { to: "/operations/building", label: "Building FArrays", desc: "The known-size constructors: literals, tabulate, range." },
-    { to: "/operations/getting-out", label: "Getting things out", desc: "The other direction: FArray back to array/Seq." },
-    { to: "/", label: "The FArray story", desc: "Why unboxing lives in signatures, not the JIT's mood." },
-  ]}
-/>

--- a/site/docs/operations/builder.mdx
+++ b/site/docs/operations/builder.mdx
@@ -121,12 +121,6 @@ compiles stdlib's ubiquitous `addOne` almost to a bare loop, and our leaner `Ref
 get the same field-hoisting. It's more than repaid by the O(1) `result()` (ArrayBuffer pays O(n) to
 finalize), so the end-to-end number is a win.
 
-And the safety property that makes the shared buffer sound: `result()` hands back the buffer with no
-copy, yet repeated `result()` calls and further appends coexist; appends only ever write past the
-current end, and a regrow reallocates a fresh array, so every snapshot stays valid. There is no
-`clear()`: it is the one operation that could clobber a shared snapshot. Starting over means a fresh
-`FArray.newBuilder`.
-
 <Related
   links={[
     { to: "/operations/building", label: "Building FArrays", desc: "The known-size constructors: literals, tabulate, range." },

--- a/site/docs/operations/building.mdx
+++ b/site/docs/operations/building.mdx
@@ -7,7 +7,6 @@ description: "Where FArrays come from: the varargs macro that unrolls to typed s
 import Link from "@docusaurus/Link";
 import BenchChart from "@site/src/components/BenchChart";
 import BenchPair from "@site/src/components/BenchPair";
-import Related from "@site/src/components/Related";
 
 <p className="lede">
   Construction is the one place this library starts a step behind by definition: a raw{" "}
@@ -109,12 +108,3 @@ For the imperative case (pushing elements one at a time when you don't know the 
 primitive boxes at the interface. FArray has a dedicated
 <Link to="/operations/builder">unboxed builder</Link> that avoids the boxing and beats even the
 standard library's specialized `int[]` builder.
-
-<Related
-  links={[
-    { to: "/operations/builder", label: "The unboxed builder", desc: "Accumulate element-by-element without boxing." },
-    { to: "/operations/getting-out", label: "Getting things out", desc: "toArray, mkString, and the zero-copy Seq wrapper." },
-    { to: "/design/java-core", label: "The node zoo", desc: "What that leaf-plus-node representation buys." },
-    { to: "/operations/map", label: "map", desc: "The first thing you'll do with what you built." },
-  ]}
-/>

--- a/site/docs/operations/building.mdx
+++ b/site/docs/operations/building.mdx
@@ -11,12 +11,11 @@ import Related from "@site/src/components/Related";
 
 <p className="lede">
   Construction is the one place this library starts a step behind by definition: a raw{" "}
-  <code>IArray(1, 2, 3)</code> (an immutable raw array) is one array
+  <code>IArray(1, 2, 3)</code> is one array
   allocation, and an FArray is that array <em>plus</em> its leaf node. That gap is accepted: the
   design principle says losing to a bare array on inherently-allocating ops is fine, losing to the
-  wrapper libraries (Scala's <code>List</code> and <code>Vector</code>, plus the array-backed{" "}
-  <code>Chunk</code> types from the fs2 and ZIO streaming
-  libraries) is not. This page is how the
+  wrapper libraries (<code>List</code>, <code>Vector</code>, and the{" "}
+  <code>Chunk</code> types) is not. This page is how the
   entry points hold that line.
 </p>
 
@@ -29,8 +28,7 @@ compiler wraps your three literals into an array, boxes each one if it's a primi
 constructor a sequence to iterate. You pay a wrapper, N boxes, and a loop to build a three-element
 collection.
 
-FArray's `apply` is `inline` (the compiler is guaranteed to expand it at each call site; not a JIT
-hint), and it forwards to a macro that never lets the `Seq` form. The macro
+FArray's `apply` is `inline`, and it forwards to a macro that never lets the `Seq` form. The macro
 reads the varargs literal straight off the syntax tree and unrolls it: it counts the arguments,
 dispatches on the *static element type* to pick the concrete leaf kind, and emits the stores
 directly:

--- a/site/docs/operations/collect.mdx
+++ b/site/docs/operations/collect.mdx
@@ -70,13 +70,14 @@ The fine print:
 
 ## Eight pattern matches in one method
 
-A lone collect is the friendliest case a rival will ever see: one call site, one `PartialFunction`
-class, and the JIT devirtualizes and inlines the whole consultation. Real methods aren't like that.
-With eight distinct pattern matches through `collect` in one method (a parser, a router, any
-dispatch-heavy code), every rival funnels eight PF classes through its one shared collect loop:
-the `applyOrElse` site goes megamorphic, stops inlining, and on primitives re-boxes every element.
-FArray's collect has no shared site to poison; the macro gave each call site its own loop at
-compile time:
+This is the [method-size effect](/operations/map#where-it-stops-being-a-tie) again, in collect's
+clothing. A lone collect is the friendliest case a rival sees — one call site, one `PartialFunction`
+class, fully inlined — but pack eight distinct pattern matches into one method (a parser, a router,
+any dispatch-heavy code) and every rival funnels eight PF classes through its one shared collect
+loop. Collect's twist over `map`: the shared site is a `PartialFunction.applyOrElse`, which is
+generic, so once it goes megamorphic it not only loses inlining but *re-boxes* every primitive —
+where `map`'s specialized lambda did not. FArray's collect has no shared site to poison; the macro
+gave each call site its own loop at compile time:
 
 <BenchPair
   int="CollectMegaIntBenchmark"
@@ -92,6 +93,6 @@ the eager op so a lone `collect` gets it too.
   links={[
     { to: "/fusion/stages", label: "Fused collect", desc: "The same pick-apart, inside a whole-pipeline loop." },
     { to: "/operations/map", label: "map", desc: "The megamorphic experiment this page borrows." },
-    { to: "/chains", label: "Fast without fusion", desc: "Where per-op wins compound." },
+    { to: "/chains", label: "Motivation", desc: "Where per-op wins compound." },
   ]}
 />

--- a/site/docs/operations/collect.mdx
+++ b/site/docs/operations/collect.mdx
@@ -6,7 +6,6 @@ description: "filter + map through one pattern match: why the PartialFunction ob
 
 import Link from "@docusaurus/Link";
 import BenchPair from "@site/src/components/BenchPair";
-import Related from "@site/src/components/Related";
 
 <p className="lede">
   <code>collect</code> is filter and map in one pattern match (a Scala <code>match</code>: a switch
@@ -88,11 +87,3 @@ gave each call site its own loop at compile time:
 The same idea one level up: in a *fused* chain, `collect`'s cases splice straight into the pipeline
 loop (<Link to="/fusion/stages">stages page</Link>); this page's macro is that move, packaged for
 the eager op so a lone `collect` gets it too.
-
-<Related
-  links={[
-    { to: "/fusion/stages", label: "Fused collect", desc: "The same pick-apart, inside a whole-pipeline loop." },
-    { to: "/operations/map", label: "map", desc: "The megamorphic experiment this page borrows." },
-    { to: "/chains", label: "Why FArray", desc: "Where per-op wins compound." },
-  ]}
-/>

--- a/site/docs/operations/collect.mdx
+++ b/site/docs/operations/collect.mdx
@@ -93,6 +93,6 @@ the eager op so a lone `collect` gets it too.
   links={[
     { to: "/fusion/stages", label: "Fused collect", desc: "The same pick-apart, inside a whole-pipeline loop." },
     { to: "/operations/map", label: "map", desc: "The megamorphic experiment this page borrows." },
-    { to: "/chains", label: "Motivation", desc: "Where per-op wins compound." },
+    { to: "/chains", label: "Why FArray", desc: "Where per-op wins compound." },
   ]}
 />

--- a/site/docs/operations/folds.mdx
+++ b/site/docs/operations/folds.mdx
@@ -7,7 +7,6 @@ description: "The accumulator ops: where the boxing tax is purest, where the JIT
 import Link from "@docusaurus/Link";
 import BenchChart from "@site/src/components/BenchChart";
 import BenchPair from "@site/src/components/BenchPair";
-import Related from "@site/src/components/Related";
 
 <p className="lede">
   A fold is the purest boxing benchmark there is: no output collection, no structural work, just one
@@ -94,11 +93,3 @@ are the empty-safe spellings, one branch in front of the same loop.
 When the fold ends a *chain*,{" "}
 <Link to="/fusion/farray">fusing the chain</Link> folds without materializing any stage at all, and
 `agg` runs several folds in one pass.
-
-<Related
-  links={[
-    { to: "/chains", label: "Why FArray", desc: "Where the per-stage wins compound." },
-    { to: "/operations/map", label: "How map stays unboxed", desc: "The signature-level machinery folds share." },
-    { to: "/fusion/terminals", label: "Fused folds & agg", desc: "Several accumulators, one pass, no chain materialization." },
-  ]}
-/>

--- a/site/docs/operations/folds.mdx
+++ b/site/docs/operations/folds.mdx
@@ -37,13 +37,13 @@ The tie does not hold once the fold sits in a real method.
 
 ## The part that matters: folds in real methods
 
-Competitors' primitive folds run unboxed *because* the JIT inlines the shared generic `foldLeft`
-into the call site and specializes it; the tie above is paid for out of the method's
-inlining budget. With several folds in one method (an ordinary reporting or
-aggregation method), the budget runs out: the shared fold collapses back to its generic boxed
-signature, one call site at a time, as the method grows. We measured the collapse beginning at four
-folds per method on C2 and around twelve on Graal. The story applies verbatim to
-`java.util.stream`: a `Stream.reduce` runs unboxed only while the JIT keeps its Sink chain inlined.
+The same [method-size effect](/operations/map#where-it-stops-being-a-tie) as `map`, with a fold's
+own twist. Competitors' primitive folds run unboxed *because* the JIT inlines the shared generic
+`foldLeft` and specializes it; the lone-fold tie above is paid out of the method's inlining budget.
+With several folds in one method the budget runs out and the shared fold collapses to its generic
+boxed signature, one call site at a time — and unlike `map`, where nothing boxed, what boxes here is
+the *accumulator*, threaded through every element. We measured the collapse beginning at four folds
+per method on C2 and around twelve on Graal.
 
 FArray's fold surface is a tiny call to a compiled-once leaf, not inlined, so the
 sixth fold in a method compiles exactly like the first. The benchmark runs six reference folds in one
@@ -97,7 +97,7 @@ When the fold ends a *chain*,{" "}
 
 <Related
   links={[
-    { to: "/chains", label: "Fast without fusion", desc: "Where the per-stage wins compound." },
+    { to: "/chains", label: "Motivation", desc: "Where the per-stage wins compound." },
     { to: "/operations/map", label: "How map stays unboxed", desc: "The signature-level machinery folds share." },
     { to: "/fusion/terminals", label: "Fused folds & agg", desc: "Several accumulators, one pass, no chain materialization." },
   ]}

--- a/site/docs/operations/folds.mdx
+++ b/site/docs/operations/folds.mdx
@@ -97,7 +97,7 @@ When the fold ends a *chain*,{" "}
 
 <Related
   links={[
-    { to: "/chains", label: "Motivation", desc: "Where the per-stage wins compound." },
+    { to: "/chains", label: "Why FArray", desc: "Where the per-stage wins compound." },
     { to: "/operations/map", label: "How map stays unboxed", desc: "The signature-level machinery folds share." },
     { to: "/fusion/terminals", label: "Fused folds & agg", desc: "Several accumulators, one pass, no chain materialization." },
   ]}

--- a/site/docs/operations/getting-out.mdx
+++ b/site/docs/operations/getting-out.mdx
@@ -6,7 +6,6 @@ description: "The exits: toArray as an arraycopy, mkString, indices, and toSeq, 
 
 import Link from "@docusaurus/Link";
 import BenchChart from "@site/src/components/BenchChart";
-import Related from "@site/src/components/Related";
 
 <p className="lede">
   The exits are boring, as they should be: turning an FArray back into an
@@ -64,11 +63,3 @@ The trade: FArray pays one small wrapper allocation where `List`/`Vector` pay ze
 (they were already Seqs). That single allocation is the one un-winnable cell against a native Seq,
 and the benchmark suite omits it rather than dress it up: a loss of exactly one object,
 in exchange for having a real array underneath everywhere else.
-
-<Related
-  links={[
-    { to: "/operations/building", label: "Building FArrays", desc: "The other end, and the ClassTag trick that makes toArray fast." },
-    { to: "/operations/indexed", label: "Indexed access", desc: "Where isDefinedAt and apply actually live." },
-    { to: "/", label: "The FArray story", desc: "Why a real array underneath is the whole point." },
-  ]}
-/>

--- a/site/docs/operations/indexed.mdx
+++ b/site/docs/operations/indexed.mdx
@@ -79,6 +79,6 @@ price of being a data structure rather than a pointer, and it's paid only where 
   links={[
     { to: "/design/combinators", label: "The cost model", desc: "What the wrapper buys for the hair it costs." },
     { to: "/operations/list-parity", label: "List's own game", desc: "head/tail recursion at cons-list speed." },
-    { to: "/chains", label: "Motivation", desc: "Where single-op percents become chain multiples." },
+    { to: "/chains", label: "Why FArray", desc: "Where single-op percents become chain multiples." },
   ]}
 />

--- a/site/docs/operations/indexed.mdx
+++ b/site/docs/operations/indexed.mdx
@@ -6,7 +6,6 @@ description: "The wrapper's price measured at the smallest possible op, one read
 
 import Link from "@docusaurus/Link";
 import BenchPair from "@site/src/components/BenchPair";
-import Related from "@site/src/components/Related";
 
 <p className="lede">
   A single read is the one place a wrapper can't hide: there's no loop to amortize into, no lambda to
@@ -74,11 +73,3 @@ hierarchy) was built and measured (17–20% *slower* for
 monomorphic reads; HotSpot folds the match better), and a dedicated single-element fast path
 measured as a no-op. The conclusion stands as measured: the size-1 read floor is the irreducible
 price of being a data structure rather than a pointer, and it's paid only where n=1.
-
-<Related
-  links={[
-    { to: "/design/combinators", label: "The cost model", desc: "What the wrapper buys for the hair it costs." },
-    { to: "/operations/list-parity", label: "List's own game", desc: "head/tail recursion at cons-list speed." },
-    { to: "/chains", label: "Why FArray", desc: "Where single-op percents become chain multiples." },
-  ]}
-/>

--- a/site/docs/operations/indexed.mdx
+++ b/site/docs/operations/indexed.mdx
@@ -79,6 +79,6 @@ price of being a data structure rather than a pointer, and it's paid only where 
   links={[
     { to: "/design/combinators", label: "The cost model", desc: "What the wrapper buys for the hair it costs." },
     { to: "/operations/list-parity", label: "List's own game", desc: "head/tail recursion at cons-list speed." },
-    { to: "/chains", label: "Fast without fusion", desc: "Where single-op percents become chain multiples." },
+    { to: "/chains", label: "Motivation", desc: "Where single-op percents become chain multiples." },
   ]}
 />

--- a/site/docs/operations/list-parity.mdx
+++ b/site/docs/operations/list-parity.mdx
@@ -14,8 +14,8 @@ import BenchPair from "@site/src/components/BenchPair";
   exists for precisely that.
 </p>
 
-Terms first, for the Java reader: Scala's `List` is an immutable singly linked list (not
-`java.util.List`), and `::`, pronounced "cons", is its cell, a head plus a tail pointer, so
+Terms first, for the Java reader: `::`, pronounced "cons", is `List`'s cell, a head plus a tail
+pointer, so
 `x :: xs` prepends in O(1) and `case h :: t` pattern-matches a list apart into head and tail.
 `+:` is the same prepend on FArray.
 

--- a/site/docs/operations/searching.mdx
+++ b/site/docs/operations/searching.mdx
@@ -6,7 +6,6 @@ description: "The short-circuit engine and its loop-shape lesson, the backward s
 
 import Link from "@docusaurus/Link";
 import BenchPair from "@site/src/components/BenchPair";
-import Related from "@site/src/components/Related";
 
 <p className="lede">
   Everything on this page answers a question and stops: is this element here, where does this run
@@ -77,11 +76,3 @@ one value and a handful of short verifications:
 The boundary: a pathological input (long needle of one repeated value over a haystack of the
 same value) degrades toward O(n·m), which KMP's guarantee avoids. Collection workloads don't look
 like that, and the 0.76× → 2.2× swing is what the guarantee was costing on everything else.
-
-<Related
-  links={[
-    { to: "/operations/indexed", label: "Indexed access", desc: "The other read-only family, and the wrapper tax priced exactly." },
-    { to: "/fusion/terminals", label: "Fused search terminals", desc: "find/exists that stop a whole pipeline, not just a scan." },
-    { to: "/operations/folds", label: "Folds & reduces", desc: "The scans that don't stop." },
-  ]}
-/>

--- a/site/docs/operations/searching.mdx
+++ b/site/docs/operations/searching.mdx
@@ -71,7 +71,7 @@ one value and a handful of short verifications:
 <BenchPair
   int="SearchSliceIntBenchmark"
   str="SearchSliceStrBenchmark"
-  caption="The slice-search family, 3-element needle from the middle of the haystack. The candidate-scan ops are the win: on Int indexOfSlice/containsSlice run 2.1–2.4× and lastIndexOfSlice 2.4–2.8× over the best rival (where the old KMP-shaped code measured 0.76×, a loss); on String (every compare an equals call, a cost all share) they still lead 1.2–1.4×. The bounded compares split by kind: on Int startsWith/endsWith run ~1.3× and sameElements/segmentLength tie; on String those same fixed-length compares sit slightly BELOW parity (startsWith ~0.57×, sameElements/segmentLength ~0.9×): a Ref compare pays a node-match + checkcast per read, and a 3-element compare has no loop to amortize it into, the same nano-op floor the indexed-access page prices. The candidate scans win because they amortize; the tiny compares don't, so they sit at the Ref read floor."
+  caption="The slice-search family, a 3-element needle from the middle of the haystack. The candidate-scan ops are the win: on Int, indexOfSlice/containsSlice run 2.1–2.4× and lastIndexOfSlice 2.4–2.8× over the best rival; on String, where every compare is an equals, they still lead 1.2–1.4×. The fixed-length compares (startsWith/endsWith/sameElements) are the exception. With no loop to amortize the wrapper's per-read cost into, on String they sit slightly below parity (startsWith ~0.57×) — the same nano-op floor the indexed-access page prices. Candidate scans win because they amortize; the tiny compares don't."
 />
 
 The boundary: a pathological input (long needle of one repeated value over a haystack of the

--- a/site/docs/semantics.mdx
+++ b/site/docs/semantics.mdx
@@ -31,6 +31,18 @@ large FArray long-term, break the tie by materializing: any elementwise operatio
 (`slice.map(identity)`) or `FArray.from(slice)` copies the two elements into fresh storage and
 drops the reference.
 
+## Safe to share across threads
+
+An FArray (and an FSet) is immutable, and you can publish one and read it from many threads at once
+without synchronizing. The only shared mutable state is the cache a lazy node uses so it doesn't
+re-materialize itself: the first traversal that needs a flat leaf computes it and stores it in a
+plain field, with no lock and no `volatile`. That store is a benign data race — the
+`String.hashCode` idiom — safe because the two things that make that idiom safe both hold here: the
+cached value is an immutable leaf whose fields are `final` (so any thread that reads the reference
+sees a fully constructed value), and every thread computes the *same* leaf, so a lost race only
+costs a little redundant work. The result is always correct. Put an FArray in a shared cache and
+read it concurrently; nothing tears.
+
 ## Reference identity differs where copying was avoided
 
 A `filter` that keeps everything returns the same object, not a copy. `map` on an empty FArray

--- a/site/docs/use.mdx
+++ b/site/docs/use.mdx
@@ -14,7 +14,10 @@ description: "Coordinates, license, requirements, and a straight answer on matur
 
 MIT licensed. Source at [github.com/oyvindberg/farray](https://github.com/oyvindberg/farray).
 Requires Scala 3.8 or later. Built and benchmarked on JDK 25; the Java core uses sealed classes, so
-JDK 17 is the floor.
+JDK 17 is the floor. JVM only — there is no Scala.js or Scala Native cross-build. On memory: a
+materialized `FArray[Int]` is its `int[]` plus one small leaf node (a couple of object headers) and
+no per-element wrapper; lazy `take`/`++`/`reverse` nodes add O(depth) small objects until something
+forces them flat.
 
 ```scala
 // sbt


### PR DESCRIPTION
Doc-only, from three rounds of a four-persona critical readthrough (veteran Scala dev, mid-level Java/Kotlin dev, JVM-shop CTO, skimmer — two AI-skeptics). Final verdict: **Veteran yes, Java dev mostly, CTO mostly, skimmer yes** — the "mostly"s limited only by things the docs can't honestly change (not-for-Kotlin, AI-built M1 experiment). Nothing factually wrong; all cross-links resolve.

**Round 1 — dedup & consolidate**
- Deduped repeated term glosses (`inline`/`List`/`IArray`/`Vector`/`Function1`/`Chunk`) re-defined on nearly every page; index keeps the canonical first-use gloss.
- Consolidated the "method-size effect": `map` is canonical; `collect`/`folds` cross-link it and state only their distinct twist (collect's generic `applyOrElse` re-boxes; folds box the accumulator).
- Added a verified **thread-safety** contract to `semantics` (lazy memoization is the `String.hashCode` benign-race idiom, safe because the cached leaf's fields are `final`).
- Removed a third duplicate `ColdPipeline` chart; split a caption ratio-wall; cut a duplicate builder-safety paragraph.

**Round 2 — polish**
- Renamed the two section openers to distinct, parallel titles: **"Why FArray"** (chains) and **"Why fusion"** (fusion benchmarks), with matching eyebrows ("what FArray buys" / "what fusion buys").
- De-duped the `StreamPipeline` chart (kept on sources, linked from benchmarks); fixed a doubled Related link and a mislabeled one.
- `use.mdx`: stated JVM-only (no Scala.js/Native) and FArray's own memory footprint.
- `index` "Claude is why" bullet leads with the test gate.

**Round 3**
- Removed all `<Related>` footer link blocks (and their imports) from every page, per request; navigation is the sidebar plus inline cross-links.

Site builds clean throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
