### PR TITLE
tests: cover filterNot fusion + deep heterogeneous fused pipelines

### DIFF
--- a/tests/src/scala/farray/FarrayTest.scala
+++ b/tests/src/scala/farray/FarrayTest.scala
@@ -1178,6 +1178,8 @@ class FListTest:
     check("cc.materialize")(_.fuse.map(x => P2(x, x * 10)).filter(_.a > 0).run.toList)(_.filter(_ > 0).map(x => P2(x, x * 10)))
     // new stages
     check("collect")(_.fuse.collect { case x if x % 2 == 0 => x * 3 }.run.toList)(_.collect { case x if x % 2 == 0 => x * 3 })
+    check("filterNot")(_.fuse.filterNot(_ % 2 == 0).run.toList)(_.filterNot(_ % 2 == 0))
+    check("filterNot.map")(_.fuse.filterNot(_ > 0).map(_ * 2).run.toList)(_.filterNot(_ > 0).map(_ * 2))
     check("takeWhile")(_.fuse.takeWhile(_ < 5).run.toList)(_.takeWhile(_ < 5))
     check("dropWhile")(_.fuse.dropWhile(_ < 5).run.toList)(_.dropWhile(_ < 5))
     check("distinct")(_.fuse.distinct.run.toList)(_.distinct)
@@ -1206,6 +1208,104 @@ class FListTest:
           .map(_._1)
       )
       t2 += 1
+
+  // ---- DEEP, HETEROGENEOUS pipelines: long chains that MIX flatMap + distinct + scanLeft + collect +
+  //      filterNot + zipWithIndex + grouping terminals in ONE fused pass. The fuzz above tests each stage
+  //      mostly in isolation / short combos; this exercises the interactions (done-break escaping nested
+  //      flatMap loops while distinct/scanLeft carry state; counters advancing under an expanding flatMap;
+  //      a grouping terminal after a multi-stage prep). Every pipeline == the identical List pipeline, over
+  //      random data AND tree-shaped sources (Concat / append-chain → the <kind>At fallback in flatMap). ----
+  @Test def test_fuse_complex_pipelines: Unit =
+    val rng = new java.util.Random(0xc0ffeedeadL)
+    val zf = FArray(3, 1, 4, 1, 5, 9, 2, 6); val zl = List(3, 1, 4, 1, 5, 9, 2, 6) // zip operand
+    def mk(xs: List[Int]): FArray[Int] = rng.nextInt(3) match
+      case 0 => FArray.fromIterable(xs)
+      case 1 => xs.foldLeft(FArray.empty[Int])(_ :+ _) // append-chain tree
+      case _ => val (l, r) = xs.splitAt(xs.length / 2); FArray.fromIterable(l) ++ FArray.fromIterable(r) // Concat
+    def check[X](label: String)(fa: FArray[Int] => X)(la: List[Int] => X): Unit =
+      var t = 0
+      while t < 300 do
+        val xs = List.tabulate(rng.nextInt(24))(_ => rng.nextInt(16) - 4) // dups, collisions, negatives, empties
+        val got = fa(mk(xs)); val exp = la(xs)
+        assert(got == exp, s"$label on $xs:\n  got $got\n  exp $exp")
+        t += 1
+
+    // 1. filter → flatMap → filterNot → distinct → map → take  (expand, then dedup a stateful stream, bounded)
+    check("filter.flatMap.filterNot.distinct.map.take")(
+      _.fuse.filter(_ > -2).flatMap(x => FArray(x, -x)).filterNot(_ == 0).distinct.map(_ * 2).take(6).run.toList
+    )(_.filter(_ > -2).flatMap(x => List(x, -x)).filterNot(_ == 0).distinct.map(_ * 2).take(6))
+    // 2. tuple map → filter → flatMap (pair splat) → collect → scanLeft  (decomposition survives the flatMap)
+    check("map(tuple).filter.flatMap.collect.scanLeft")(
+      _.fuse.map(x => (x, x * x)).filter(_._1 % 2 == 0).flatMap(t => FArray(t._1, t._2)).collect { case v if v >= 0 => v }.scanLeft(0)(_ + _).run.toList
+    )(_.map(x => (x, x * x)).filter(_._1 % 2 == 0).flatMap(t => List(t._1, t._2)).collect { case v if v >= 0 => v }.scanLeft(0)(_ + _))
+    // 3. flatMap → flatMap → filter → take  (done must break BOTH inner loops mid-expansion)
+    check("flatMap.flatMap.filter.take")(
+      _.fuse.flatMap(x => FArray(x, x + 1)).flatMap(y => FArray(y, y * 10)).filter(_ > 0).take(7).run.toList
+    )(_.flatMap(x => List(x, x + 1)).flatMap(y => List(y, y * 10)).filter(_ > 0).take(7))
+    // 4. zipWithIndex → filter(on index) → flatMap → distinctBy → map  (post-filter index feeds an expansion)
+    check("zipWithIndex.filter.flatMap.distinctBy.map")(
+      _.fuse.zipWithIndex.filter(_._2 % 2 == 0).flatMap(t => FArray(t._1, t._2)).distinctBy(_ % 5).map(_ + 1).run.toList
+    )(_.zipWithIndex.filter(_._2 % 2 == 0).flatMap(t => List(t._1, t._2)).distinctBy(_ % 5).map(_ + 1))
+    // 5. collect → scanLeft → filterNot → takeWhile  (running fold gated by a downstream short-circuit)
+    check("collect.scanLeft.filterNot.takeWhile")(
+      _.fuse.collect { case x if x != 0 => x * 3 }.scanLeft(100)(_ - _).filterNot(_ < -50).takeWhile(_ < 500).run.toList
+    )(_.collect { case x if x != 0 => x * 3 }.scanLeft(100)(_ - _).filterNot(_ < -50).takeWhile(_ < 500))
+    // 6. dropWhile → flatMap(variable-size inner) → distinct → drop → take
+    check("dropWhile.flatMap.distinct.drop.take")(
+      _.fuse.dropWhile(_ < 0).flatMap(x => FArray.tabulate(if x > 0 then 2 else 0)(_ => x)).distinct.drop(1).take(5).run.toList
+    )(_.dropWhile(_ < 0).flatMap(x => List.fill(if x > 0 then 2 else 0)(x)).distinct.drop(1).take(5))
+    // 7. zip → filter → flatMap → scanLeft  (lock-step source feeding an expansion + running fold)
+    check("zip.filter.flatMap.scanLeft")(
+      _.fuse.zip(zf).filter((a, b) => (a + b) % 2 == 0).flatMap((a, b) => FArray(a, b)).scanLeft(0)(_ + _).run.toList
+    )(_.zip(zl).filter { case (a, b) => (a + b) % 2 == 0 }.flatMap { case (a, b) => List(a, b) }.scanLeft(0)(_ + _))
+
+    // ---- grouping terminals AFTER a multi-stage prep chain (not just after one filter/map) ----
+    // G1: filter → flatMap → map → groupReduceBy  (unboxed Int-keyed reduce over an expanded stream)
+    check("filter.flatMap.map.groupReduceBy")(
+      _.fuse.filter(_ > -2).flatMap(x => FArray(x, x % 3)).map(_ + 1).groupReduceBy(_ % 4)(x => x)(_ + _)
+    )(_.filter(_ > -2).flatMap(x => List(x, x % 3)).map(_ + 1).groupMapReduce(_ % 4)(x => x)(_ + _))
+    // G2: map → filterNot → flatMap → groupMapReduce (Map builder path)
+    check("map.filterNot.flatMap.groupMapReduce")(
+      _.fuse.map(_ + 1).filterNot(_ % 2 == 0).flatMap(x => FArray(x, -x)).groupMapReduce(_ % 3)(_ => 1)(_ + _)
+    )(_.map(_ + 1).filterNot(_ % 2 == 0).flatMap(x => List(x, -x)).groupMapReduce(_ % 3)(_ => 1)(_ + _))
+    // G3: flatMap → filter → groupBy  (per-key Lists, encounter order preserved within each group)
+    check("flatMap.filter.groupBy")(
+      _.fuse.flatMap(x => FArray(x, x * 2)).filter(_ >= 0).groupBy(_ % 3)
+    )(_.flatMap(x => List(x, x * 2)).filter(_ >= 0).groupBy(_ % 3))
+    // G4: filter → distinct → groupCount  (dedup THEN tally per key)
+    check("filter.distinct.groupCount")(
+      _.fuse.filter(_ > -3).distinct.groupCount(_ % 3)
+    )(_.filter(_ > -3).distinct.groupBy(_ % 3).view.mapValues(_.size).toMap)
+    // G5: collect → map → groupSum  (unboxed value accumulator per key after a partial-function prep)
+    check("collect.map.groupSum")(
+      _.fuse.collect { case x if x != 0 => x * 2 }.map(_ + 1).groupSum(_ % 4)(x => x)
+    )(_.collect { case x if x != 0 => x * 2 }.map(_ + 1).groupBy(_ % 4).view.mapValues(_.sum).toMap)
+
+    // ---- Long / Double / Ref element kinds through a deep heterogeneous chain ----
+    var tk = 0
+    while tk < 200 do
+      val xs = List.tabulate(rng.nextInt(20))(_ => rng.nextInt(16) - 4)
+      // Long: flatMap + distinct + scanLeft + take
+      assert(
+        FArray.fromIterable(xs.map(_.toLong)).fuse.filter(_ > -2L).flatMap(x => FArray(x, x * 2L)).distinct.scanLeft(0L)(_ + _).take(8).run.toList ==
+          xs.map(_.toLong).filter(_ > -2L).flatMap(x => List(x, x * 2L)).distinct.scanLeft(0L)(_ + _).take(8)
+      )
+      // Double: map + filter + flatMap + drop
+      assert(
+        FArray.fromIterable(xs.map(_.toDouble)).fuse.map(_ + 0.5).filter(_ > 0.0).flatMap(x => FArray(x, -x)).drop(1).run.toList ==
+          xs.map(_.toDouble).map(_ + 0.5).filter(_ > 0.0).flatMap(x => List(x, -x)).drop(1)
+      )
+      // Ref (String): collect + flatMap + distinct + map + take
+      assert(
+        FArray.fromIterable(xs.map(_.toString)).fuse.collect { case s if s.length <= 2 => s }.flatMap(s => FArray(s, s + "!")).distinct.map(_.length).take(6).run.toList ==
+          xs.map(_.toString).collect { case s if s.length <= 2 => s }.flatMap(s => List(s, s + "!")).distinct.map(_.length).take(6)
+      )
+      // Ref grouping: flatMap + filter + groupReduce (String keys, min per key)
+      assert(
+        FArray.fromIterable(xs.map(_.toString)).fuse.flatMap(s => FArray(s, s.reverse)).filter(_.nonEmpty).groupReduceBy(_.length)(s => s)((a, b) => if a <= b then a else b) ==
+          xs.map(_.toString).flatMap(s => List(s, s.reverse)).filter(_.nonEmpty).groupMapReduce(_.length)(s => s)((a, b) => if a <= b then a else b)
+      )
+      tk += 1
 
   // ---- case-class / nested-product decomposition (same machinery as tuples, via caseFields) ----
   @Test def test_fuse_caseclass: Unit =
@@ -1461,6 +1561,12 @@ class FListTest:
     aeq(l.collect { case 3 => 30; case 5 => 50 }, r.fuse.collect { case 3 => 30; case 5 => 50 }.toList)
     // collect changing the element type, then a further stage
     aeq(l.collect { case x if x % 2 == 0 => x.toString }.map(_ + "!"), r.fuse.collect { case x if x % 2 == 0 => x.toString }.map(_ + "!").toList)
+    // filterNot (the complement of filter — same pass, negated predicate)
+    aeq(l.filterNot(_ % 2 == 0), r.fuse.filterNot(_ % 2 == 0).toList)
+    aeq(l.filterNot(_ => true), r.fuse.filterNot(_ => true).toList) // all out
+    aeq(l.filterNot(_ => false), r.fuse.filterNot(_ => false).toList) // all kept
+    aeq(l.map(_ + 1).filterNot(_ % 3 == 0).map(_ * 2), r.fuse.map(_ + 1).filterNot(_ % 3 == 0).map(_ * 2).toList) // composed
+    aeq(List("a", "bb", "ccc").filterNot(_.length >= 2), FArray("a", "bb", "ccc").fuse.filterNot(_.length >= 2).toList) // Ref
     // takeWhile / dropWhile (incl. all / none boundaries)
     aeq(l.takeWhile(_ < 5), r.fuse.takeWhile(_ < 5).toList)
     aeq(l.dropWhile(_ < 5), r.fuse.dropWhile(_ < 5).toList)

--- a/tests/src/scala/farray/FarrayTest.scala
+++ b/tests/src/scala/farray/FarrayTest.scala
@@ -1297,12 +1297,26 @@ class FListTest:
       )
       // Ref (String): collect + flatMap + distinct + map + take
       assert(
-        FArray.fromIterable(xs.map(_.toString)).fuse.collect { case s if s.length <= 2 => s }.flatMap(s => FArray(s, s + "!")).distinct.map(_.length).take(6).run.toList ==
+        FArray
+          .fromIterable(xs.map(_.toString))
+          .fuse
+          .collect { case s if s.length <= 2 => s }
+          .flatMap(s => FArray(s, s + "!"))
+          .distinct
+          .map(_.length)
+          .take(6)
+          .run
+          .toList ==
           xs.map(_.toString).collect { case s if s.length <= 2 => s }.flatMap(s => List(s, s + "!")).distinct.map(_.length).take(6)
       )
       // Ref grouping: flatMap + filter + groupReduce (String keys, min per key)
       assert(
-        FArray.fromIterable(xs.map(_.toString)).fuse.flatMap(s => FArray(s, s.reverse)).filter(_.nonEmpty).groupReduceBy(_.length)(s => s)((a, b) => if a <= b then a else b) ==
+        FArray
+          .fromIterable(xs.map(_.toString))
+          .fuse
+          .flatMap(s => FArray(s, s.reverse))
+          .filter(_.nonEmpty)
+          .groupReduceBy(_.length)(s => s)((a, b) => if a <= b then a else b) ==
           xs.map(_.toString).flatMap(s => List(s, s.reverse)).filter(_.nonEmpty).groupMapReduce(_.length)(s => s)((a, b) => if a <= b then a else b)
       )
       tk += 1


### PR DESCRIPTION
## What

Closes two real gaps in the fused-pipeline correctness suite. It tested each combinator well in isolation and in short 2–3 stage combos, plus one long but **homogeneous** `map`/`filter`/`take`/`drop` chain — but nothing deep and heterogeneous.

### 1. `filterNot` fusion parity
`filterNot` is a fuse stage marker (`Fuse.scala:35`) but had **no** fuse-vs-`List` assertion anywhere — it appeared only in eager-`FArray` tests. Added:
- explicit cases in `test_fuse_stages` (all-out / all-kept / composed / Ref)
- two `check(...)` lines in the `test_fuse_fuzz` harness

### 2. Deep, heterogeneous pipelines — `test_fuse_complex_pipelines`
Before this, **`flatMap` was never combined** with `distinct`/`scanLeft`/`collect`/`zipWithIndex`/grouping in one pipeline, and grouping terminals were only tested right after a single `filter`/`map`. The new test runs deep mixed chains over the same randomized-data + tree-shaped-source harness (Concat / append-chain → the `${K}At` fallback), each asserted against the identical `List` pipeline:

- `filter → flatMap → filterNot → distinct → map → take`
- `map(tuple) → filter → flatMap(pair-splat) → collect → scanLeft`
- `flatMap → flatMap → filter → take` (done-break must escape **both** inner loops mid-expansion)
- `zipWithIndex → filter(index) → flatMap → distinctBy → map`
- `collect → scanLeft → filterNot → takeWhile`, `dropWhile → flatMap → distinct → drop → take`, `zip → filter → flatMap → scanLeft`
- **grouping after a prep chain:** `filter.flatMap.map.groupReduceBy`, `map.filterNot.flatMap.groupMapReduce`, `flatMap.filter.groupBy`, `filter.distinct.groupCount`, `collect.map.groupSum`
- **Long / Double / String** kinds each through a deep heterogeneous chain

12 pipelines × 300 random inputs + 4 kind-specific chains × 200.

## Test
`bleep test tests` → **485 passed, 0 failed**. Tests-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)