### PR TITLE
ci: grant release job contents:write (fix GitHub-release 403)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ build ]
     if: "startsWith(github.ref, 'refs/tags/v')"
+    permissions:
+      contents: write   # create the GitHub Release for the tag
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The `v1.0.0-M1` release **published to Maven Central successfully** (deployment state PUBLISHED, synced to repo1.maven.org). The overall job still went red only because the trailing "GitHub release" step returned **403** — the workflow has no `permissions:` block, so the default `GITHUB_TOKEN` is read-only and can't create a Release.

Adds `permissions: contents: write` to the `release` job so the next tag push creates its GitHub Release cleanly. No other changes. (The 1.0.0-M1 GitHub Release was created manually in the meantime.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)